### PR TITLE
feat(argo): wire batch stage-in + write-back into the DAG (bloom #532)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ Container orchestration for sleap-roots inference pipeline.
 
 This repository defines a modular, GPU-accelerated image processing pipeline for plant root phenotyping using [SLEAP](https://sleap.ai), orchestrated via [Argo Workflows](https://argo-workflows.readthedocs.io).
 
-The pipeline consists of three main steps:
-1. **models-downloader** – Prepares model files for inference
-2. **predictor** – Runs SLEAP predictions on input image sets
+The pipeline consists of four stages (A4, updated 2026-07-30 — `models-downloader` was dropped
+earlier; models load in-process from the wandb registry):
+1. **images-downloader** – Stages a batch of scans in from Bloom via `bloomctl`
+2. **predictor** – Runs SLEAP predictions on the staged image sets (GPU)
 3. **trait-extractor** – Extracts phenotypic traits from predictions
+4. **write-back** – Writes the resulting traits back into Bloom via `bloomctl`
 
 It is designed for reproducible, containerized execution using Kubernetes.
 
@@ -65,9 +67,10 @@ echo "Argo CLI configured for Argo Server at gpu-master:8888 using token auth."
 ```text
 .
 ├── sleap-roots-pipeline.yaml                    # Main Argo Workflow definition
-├── models-downloader-template.yaml              # WorkflowTemplate: downloads models
+├── sleap-roots-images-downloader-template.yaml  # WorkflowTemplate: stages scans in via bloomctl
 ├── sleap-roots-predictor-template.yaml          # WorkflowTemplate: runs predictions
 ├── sleap-roots-trait-extractor-template.yaml    # WorkflowTemplate: extracts traits
+├── sleap-roots-write-back-template.yaml         # WorkflowTemplate: writes traits back via bloomctl
 ├── runai_run_pipeline.sh                        # GPU cluster launcher for Run:AI (runai-talmo-lab)
 ├── local_run_pipeline_first_time.sh             # Local WSL2/Docker Desktop test runner
 ├── local-WSL2-*.yaml                            # Local-only templates and workflow configs
@@ -155,9 +158,10 @@ kubectl describe node docker-desktop | grep -A 5 "Capacity"
 ## 📋 Creating WorkflowTemplates (One-Time per Namespace)
 
 ```bash
-argo template create models-downloader-template.yaml -n runai-talmo-lab
+argo template create sleap-roots-images-downloader-template.yaml -n runai-talmo-lab
 argo template create sleap-roots-predictor-template.yaml -n runai-talmo-lab
 argo template create sleap-roots-trait-extractor-template.yaml -n runai-talmo-lab
+argo template create sleap-roots-write-back-template.yaml -n runai-talmo-lab
 ```
 
 Check with:
@@ -172,7 +176,7 @@ argo template list -n runai-talmo-lab
 
 ```bash
 argo list
-argo submit sleap-roots-pipeline.yaml --watch
+argo submit sleap-roots-pipeline.yaml --parameter scan-ids=<id1>,<id2> --watch
 ```
 
 ---

--- a/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
+++ b/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
@@ -1,0 +1,187 @@
+# A4 — wire batch stage-in + write-back into the Argo DAG (design)
+
+**Date:** 2026-07-28 · **Owner:** eberrigan · **Tier:** A4 (roadmap `docs/bloom-integration/roadmap.md`)
+**Status:** design (brainstormed 2026-07-28); pending review → implementation planning.
+
+## 1. Goal
+
+Turn `sleap-roots-pipeline.yaml`'s DAG from a hardcoded two-task PoC (`predictor`→`trait-extractor`
+against one fixed scan directory) into a real four-task per-batch pipeline that stages scans in and
+writes results back via `bloomctl`'s new batch commands
+([bloom #532](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/532)):
+
+```
+images-downloader → predictor → trait-extractor → write-back
+```
+
+This is the next unblocked A4 deliverable per the roadmap's A4 change-breakdown table
+(`images-downloader`/`workflow template`/`write-back` rows) and the
+[2026-07-06 design doc](2026-07-06-a4-request-driven-pipeline-design.md) (component 2 of §11:
+"the per-batch Argo `WorkflowTemplate`... this repo").
+
+## 2. Context — what's already true
+
+- **`predictor` and `trait-extractor` need no changes.** Both are already batch-capable
+  (`sleap_roots_predict.run_batch`, `trait_extractor.extract_batch`) — they already discover and
+  loop every scan under a directory. The gap is purely the two `bloomctl`-based stages.
+- **The `bloomctl` image tag matters.** `ghcr.io/salk-harnessing-plants-initiative/bloomctl:0.1.0a2`
+  (`sha-1bb03f6`, referenced elsewhere in the roadmap) predates
+  [bloom #532](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/532) and lacks the
+  batch commands. The correct tag is **`sha-61959bd`** (auto-built on #532's push to `staging`; no
+  versioned release has been cut yet — see the roadmap's 2026-07-27 status-log entry).
+- **`bloomctl` auth is email+password only**, stored as a dotenv file at `~/.bloom/credentials.txt`
+  (`bloomcli/src/bloomctl/credentials.py`) — no service-role-key path exists. `load_credentials()`
+  reads that file directly; it does not require the interactive `bloomctl login` command to have
+  run in-process. This means a Kubernetes Secret mounted at that path works today, with zero
+  `bloomctl` code changes (bloom #398, "non-interactive auth," is not a dependency of this change).
+- **The actual credential (sleap-roots-pipeline#17) is being provisioned in a parallel session**
+  (`salk-bloom`, see `C:\vaults\sleap-roots\bloom-pipeline-integration\handoff_prompts\
+  new_session_prompt_a4_credential_provisioning.md`). All the DB-side grants `bloom_workflows`
+  needs already exist (verified against the actual migrations); what's missing is the account
+  itself. This change wires the *reference* to a Secret (name TBD, e.g.
+  `bloom-pipeline-credentials`); it will not be live/functional until that other session's work
+  lands, and that's expected — not a blocker for merging this change.
+
+## 3. Architecture
+
+**DAG:**
+- `images-downloader` (new): `bloomctl cyl batch-download-for-predict <images-input-dir>
+  --scan-ids {{workflow.parameters.scan-ids}}`. Writes into the same `images-input-dir` volume
+  `predictor` already reads.
+- `predictor` (unchanged).
+- `trait-extractor` (unchanged).
+- `write-back` (new): `bloomctl cyl batch-ingest-result <traits-output-dir> --predictions-dir
+  <predictions-output-dir>`. Reads the same `traits-output-dir`/`predictions-output-dir` volumes
+  `trait-extractor`/`predictor` already write.
+
+```yaml
+tasks:
+  - name: images-downloader
+    templateRef: {name: sleap-roots-images-downloader-template, template: images-downloader}
+  - name: predictor
+    templateRef: {name: sleap-roots-predictor-template, template: predictor}
+    dependencies: [images-downloader]
+  - name: trait-extractor
+    templateRef: {name: sleap-roots-trait-extractor-template, template: trait-extractor}
+    dependencies: [predictor]
+  - name: write-back
+    templateRef: {name: sleap-roots-write-back-template, template: write-back}
+    dependencies: [trait-extractor]
+```
+
+**Workflow-level input:** `arguments.parameters: [{name: scan-ids, value: ""}]` — a caller (manual
+`argo submit --parameter scan-ids=...` for now; Bloom's not-yet-built trigger route later) supplies
+the batch. Volumes stay the existing fixed `a4_poc` hostPath paths — no per-run path isolation yet,
+since nothing can submit concurrently regardless (no trigger route exists to do so). This is a
+known, explicitly-deferred gap (§8).
+
+**Deferred, not part of this change:** the Argo semaphore (design §9) for concurrent-batch
+concurrency control — there is no caller yet that could submit more than one batch at a time, so
+there's nothing to gate. Revisit alongside the Bloom trigger route/dispatch worker
+(bloom #11/#404).
+
+## 4. Task-level specs
+
+Two new single-task `WorkflowTemplate` files, matching the existing one-file-per-task convention
+(`sleap-roots-predictor-template.yaml`, `sleap-roots-trait-extractor-template.yaml`):
+
+**`sleap-roots-images-downloader-template.yaml`:**
+```yaml
+container:
+  image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+  args: ["cyl", "batch-download-for-predict", "/workspace/images_input",
+         "--scan-ids", "{{workflow.parameters.scan-ids}}"]
+  env: [{name: HOME, value: /home/bloom}]
+  volumeMounts:
+    - {name: images-input-dir, mountPath: /workspace/images_input}
+    - {name: bloom-credentials, mountPath: /home/bloom/.bloom/credentials.txt,
+       subPath: credentials.txt, readOnly: true}
+```
+
+**`sleap-roots-write-back-template.yaml`:**
+```yaml
+container:
+  image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+  args: ["cyl", "batch-ingest-result", "/workspace/input",
+         "--predictions-dir", "/workspace/predictions"]
+  env: [{name: HOME, value: /home/bloom}]
+  volumeMounts:
+    - {name: traits-output-dir, mountPath: /workspace/input}
+    - {name: predictions-output-dir, mountPath: /workspace/predictions}
+    - {name: bloom-credentials, mountPath: /home/bloom/.bloom/credentials.txt,
+       subPath: credentials.txt, readOnly: true}
+```
+
+Both: `priorityClassName: interactive-preemptible` + `retryStrategy` (limit 2), matching
+`trait-extractor`'s CPU-task pattern (not `predictor`'s GPU one). Modest CPU/memory requests — both
+are I/O-bound HTTPS calls, not compute. Neither sets `privileged: true`/`runAsUser: 0` — unlike
+`predictor`/`trait-extractor`, this genuinely doesn't need it (non-root image, no GPU/device
+access), and it would just be copying an already-flagged TODO debt forward without reason.
+
+**Why `HOME=/home/bloom` is set explicitly:** `bloomcli`'s Dockerfile creates its runtime user via
+`adduser --system` with no explicit home directory, so where Python's `Path.home()` resolves is
+genuinely ambiguous without it. Setting `HOME` directly sidesteps that ambiguity — `bloomctl`'s
+`load_credentials()` reads `Path.home()/.bloom/credentials.txt`, so this makes the mount path
+deterministic.
+
+**New Workflow-level volume:**
+```yaml
+- name: bloom-credentials
+  secret:
+    secretName: bloom-pipeline-credentials   # provisioned by the parallel #17 session
+```
+
+## 5. Error handling
+
+- Both new commands already implement the design doc's §8 exit-code policy internally: non-zero
+  exit if *any* item failed, exit 0 on empty input or all-ok/skipped. A whole-batch `retryStrategy`
+  retry is safe and cheap here — neither task pays a model-reload cost, and both have their own
+  skip-if-done (`batch-download-for-predict`) / idempotent-no-op (`batch-ingest-result`) logic
+  internally. This differs from `predictor`, where a whole-batch retry is more expensive.
+- Until the credential lands, both new tasks will fail with a clear `bloomctl` auth error, not a
+  silent hang or a wiring bug — worth a manifest comment so a red `images-downloader` node reads
+  correctly.
+- To verify in testing, not assume: whether `batch-download-for-predict --scan-ids ""` (the
+  parameter's empty default) exits 0 as "empty input," or errors as a CLI parse failure. This
+  determines whether an unparameterized `argo lint`/dry-submit is a safe sanity check.
+
+## 6. Validation plan
+
+No app code, no pytest — this repo's validation is manifest-level:
+1. `argo lint` on all 4 touched/new files.
+2. **Real local WSL2 dry-run.** Sync `local-WSL2-sleap-roots-pipeline.yaml` to the same four-task
+   DAG (dropping the stale leftover `models-downloader` task it still carries from before an
+   earlier A4 change dropped it on the cluster side), add matching local template files. For
+   credentials, skip the Kubernetes Secret — bind-mount the real local `~/.bloom/credentials.txt`
+   as a `hostPath` volume, so this genuinely exercises both new `bloomctl` commands against real
+   Bloom data.
+3. Live cluster E2E is **not** a validation target for this change — it's blocked on the credential
+   regardless of how well this is built. `argo lint` clean + a successful local WSL2 run are the
+   bar to merge; cluster testing happens once the credential lands.
+
+## 7. OpenSpec capability delta
+
+The existing `per-scan-pipeline` capability asserts a two-task DAG against one hardcoded scan. This
+change doesn't remove single-scan support — a single scan is just a batch of size 1 through the new
+pipeline — but it does mean there's no longer a *separate* scan-only pathway, so keeping the
+`per-scan-pipeline` id would actively mislead future readers into thinking one still exists.
+**Decision: ADD a new `per-batch-pipeline` capability, REMOVE `per-scan-pipeline`.** The new
+capability's requirements describe the four-task DAG, batch-size-agnostic (including N=1), the
+`bloomctl` image pin, and the credential-mount shape.
+
+## 8. Explicitly deferred (production follow-ups, not part of this change)
+
+- **Argo semaphore** (design §9) — no caller can submit concurrent batches yet.
+- **Per-run path isolation** — reusing one fixed `a4_poc` path is fine with zero concurrent
+  callers, but will need a real per-`pipeline_run_id`/`batch_index` scheme before production
+  traffic (ties into the not-yet-built `cyl_pipeline_runs` data model's `argo_workflow_name`/
+  `batch_index` columns).
+- **`sha-61959bd` image pin** — an interim commit-sha tag from an unreleased build. Move to a real
+  version tag once `bloomcli` cuts one, and expect to keep bumping this pin as `bloomcli` evolves.
+- **Dev-personal hostPath convention** — `images-input-dir` etc. still point at
+  `/hpi/hpi_dev/users/eberrigan/...`, not a shared production path convention.
+- **Bloom-side trigger route + `cyl_pipeline_runs` tables + dispatch worker** (bloom #11/#404) —
+  today the batch is supplied via a manual `argo submit --parameter`.
+- **Producer Argo-readiness reconciliation** (sleap-roots #259, predict #26) — a single failing
+  scan still fails/retries the *whole* predict/traits batch, not isolated.
+- **Notification** (sleap-roots-pipeline#18) — channel still undefined.

--- a/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
+++ b/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
@@ -41,6 +41,13 @@ This is the next unblocked A4 deliverable per the roadmap's A4 change-breakdown 
   itself. This change wires the *reference* to a Secret (name TBD, e.g.
   `bloom-pipeline-credentials`); it will not be live/functional until that other session's work
   lands, and that's expected — not a blocker for merging this change.
+  **[⚠️ RESOLVED 2026-07-29 — the account was created (`bloom-pipeline-workflows@salk.edu` against
+  `staging.bloom.salk.edu`) and the credential provisioned via the RunAI console as a Generic
+  secret, following the `WANDB_API_KEY` precedent (asset name gets a `genericsecret-` prefix in
+  the resulting k8s Secret). Final name: `genericsecret-bloom-staging-pipeline-credentials` — the
+  `-staging` suffix (not just `bloom-pipeline-credentials` as sketched here) is deliberate, so a
+  later production credential can't collide with/overwrite this one in the same namespace. See
+  `openspec/changes/add-per-batch-argo-workflow/design.md` for the current state.]**
 
 ## 3. Architecture
 
@@ -130,6 +137,8 @@ deterministic.
   secret:
     secretName: bloom-pipeline-credentials   # provisioned by the parallel #17 session
 ```
+**[⚠️ RESOLVED 2026-07-29 — final name is `genericsecret-bloom-staging-pipeline-credentials`, see
+the note above.]**
 
 ## 5. Error handling
 

--- a/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
+++ b/docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md
@@ -168,6 +168,14 @@ No app code, no pytest — this repo's validation is manifest-level:
    regardless of how well this is built. `argo lint` clean + a successful local WSL2 run are the
    bar to merge; cluster testing happens once the credential lands.
 
+**[⚠️ SUPERSEDED 2026-07-29 — items 2 and 3 above didn't happen as written.** The credential
+resolved faster than expected (via the RunAI console, not this session's assumption of a longer
+wait), and this machine's Docker Desktop Kubernetes was confirmed live to have no GPU resource at
+all — so a local WSL2 dry-run could never have exercised `predictor` regardless. The actual
+acceptance gate became a real submit against the RunAI cluster instead (no local dry-run at all);
+see `openspec/changes/add-per-batch-argo-workflow/design.md`'s "Testing strategy" section and
+`tasks.md` §5 for what was actually run and its real results.]**
+
 ## 7. OpenSpec capability delta
 
 The existing `per-scan-pipeline` capability asserts a two-task DAG against one hardcoded scan. This

--- a/local_run_pipeline_first_time.sh
+++ b/local_run_pipeline_first_time.sh
@@ -8,11 +8,21 @@ RED='\033[1;31m'
 NC='\033[0m' # No Color
 
 # Workflow + template paths
+# NOTE (2026-07-30): unlike the local-WSL2-*.yaml files, this script submits
+# sleap-roots-pipeline.yaml (the cluster manifest) directly against a local "argo" namespace —
+# it predates the local-WSL2-* naming convention and isn't in openspec/project.md's documented
+# local-testing path. The A4 batch-DAG change (images-downloader/write-back, four stages) was
+# validated on the real cluster only (see openspec/changes/add-per-batch-argo-workflow/), not via
+# this script — local dev testing for that DAG shape is tracked separately in #21, still open.
+# TEMPLATES below is updated so this doesn't hard-fail on a missing templateRef, but running it
+# end-to-end still isn't validated for the current four-stage DAG (no local credential, no
+# scan-ids parameter override).
 WORKFLOW_FILE="sleap-roots-pipeline.yaml"
 TEMPLATES=(
-  "models-downloader-template.yaml"
+  "sleap-roots-images-downloader-template.yaml"
   "sleap-roots-predictor-template.yaml"
   "sleap-roots-trait-extractor-template.yaml"
+  "sleap-roots-write-back-template.yaml"
 )
 
 # Timestamped log file

--- a/openspec/changes/add-per-batch-argo-workflow/design.md
+++ b/openspec/changes/add-per-batch-argo-workflow/design.md
@@ -68,9 +68,12 @@ tracked in #21.
   specifically affects sidecar *content* changes, not just prediction validity — worth folding into
   whatever eventually hardens skip-if-done (checksum-verified skip, not just existence), rather than
   fixed here.
-- **`--scan-ids ""` (the parameter's empty default) behavior.** The source implies a clean exit 0
-  (`parse_scan_ids_flag("")` → `[]`, "nothing to stage") rather than a CLI parse error, but this is
-  confirmed on the real cluster submit (`tasks.md` 5.4), not assumed here.
+- **`--scan-ids ""` (the parameter's empty default) behavior — still not separately confirmed.**
+  The source implies a clean exit 0 (`parse_scan_ids_flag("")` → `[]`, "nothing to stage") rather
+  than a CLI parse error, but task 5.4's real cluster run tested real `scan-ids` values, not the
+  empty default — this specific path remains unverified. (An earlier draft of this note claimed
+  it was confirmed; it wasn't — corrected here to match `tasks.md`.) Low priority now that the
+  real batch path is proven end-to-end; worth confirming opportunistically.
 - **Write-back can also go silently green on an empty batch.** Like `trait-extractor`'s known gap
   (sleap-roots#259), `batch-ingest-result` also exits 0 on an empty envelopes directory — so all
   four DAG nodes can succeed with zero real work done. This is the same class of issue as the

--- a/openspec/changes/add-per-batch-argo-workflow/design.md
+++ b/openspec/changes/add-per-batch-argo-workflow/design.md
@@ -36,15 +36,34 @@ separately-tracked change.
 The Argo semaphore for concurrent-batch concurrency (design §9 of the 2026-07-06 doc), per-run path
 isolation, moving off the interim image tag, the dev-personal hostPath convention, the Bloom-side
 trigger route + `cyl_pipeline_runs`/`cyl_pipeline_run_scans` tables + dispatch worker
-(bloom #11/#404), producer Argo-readiness reconciliation (predict #26 / sleap-roots #259), and
-notification (sleap-roots-pipeline#18).
+(bloom #11/#404), producer Argo-readiness reconciliation (predict #26 / sleap-roots #259),
+notification (sleap-roots-pipeline#18), and local-WSL2 dev testing for this DAG shape
+(sleap-roots-pipeline#21, updated with this change's specifics but not implemented here).
+
+## Testing strategy — real cluster submit, not a local WSL2 dry-run
+
+Checked live: this machine's Docker Desktop Kubernetes node (`desktop-control-plane`) reports no
+`nvidia.com/gpu` in its `allocatable`/`capacity` at all — `predictor` cannot schedule locally
+regardless of anything this change does. The `local-WSL2-*` variants are also already known-stale
+relative to the cluster's GHCR contract (issue #21, filed before this change existed — updated with
+these specifics, not touched here). So this change's acceptance gate is a real submit against the
+RunAI cluster (`tasks.md` §5), not a local dry-run. Local dev testing for this DAG shape stays
+tracked in #21.
 
 ## Risks
 
 - **Credential not yet provisioned.** The Secret reference is correct-by-construction but
-  non-functional until sleap-roots-pipeline#17 lands. Mitigated by not making live-cluster
-  execution a validation target for this change (see `tasks.md`) — `argo lint` + a real local WSL2
-  dry-run (bind-mounting a personal `~/.bloom/credentials.txt`) are the bar to merge.
-- **`--scan-ids ""` (the parameter's empty default) behavior is unverified.** Whether it exits 0 as
-  "empty input" or errors as a CLI parse failure determines whether an unparameterized dry-submit is
-  a safe sanity check — confirmed during the WSL2 dry-run task, not assumed here.
+  non-functional until sleap-roots-pipeline#17 lands. Two distinct failure modes are both expected
+  and both fine for this change's acceptance gate: if the `bloom-pipeline-credentials` Secret
+  object doesn't exist at all, the pod fails at volume-mount/admission time (never reaching
+  `bloomctl`); if it exists with placeholder/incomplete values, `bloomctl` itself raises a clean
+  auth error. Either is evidence the wiring is correct, not that it's broken — a real success is
+  possible only once #17 actually lands.
+- **`--scan-ids ""` (the parameter's empty default) behavior.** The source implies a clean exit 0
+  (`parse_scan_ids_flag("")` → `[]`, "nothing to stage") rather than a CLI parse error, but this is
+  confirmed on the real cluster submit (`tasks.md` 5.4), not assumed here.
+- **Write-back can also go silently green on an empty batch.** Like `trait-extractor`'s known gap
+  (sleap-roots#259), `batch-ingest-result` also exits 0 on an empty envelopes directory — so all
+  four DAG nodes can succeed with zero real work done. This is the same class of issue as the
+  already-deferred "producer Argo-readiness reconciliation" item above; not solved by this change,
+  called out here so it isn't mistaken for new behavior introduced later.

--- a/openspec/changes/add-per-batch-argo-workflow/design.md
+++ b/openspec/changes/add-per-batch-argo-workflow/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Full architecture, rationale, and deferred items live in
+`docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md` (approved 2026-07-28), which
+itself grounds in `docs/superpowers/specs/2026-07-06-a4-request-driven-pipeline-design.md`. This
+change implements only the four-task DAG wiring in this declarative repo; everything else in the
+design (semaphore, Bloom trigger route, producer Argo-readiness, notification) is a later,
+separately-tracked change.
+
+## Key decisions (scoped to this change)
+
+- **`predictor`/`trait-extractor` are unchanged.** Both are already batch-capable
+  (`run_batch`/`extract_batch`); the gap was purely the two `bloomctl`-based stages.
+- **Image pin: `sha-61959bd`, not `0.1.0a2`/`sha-1bb03f6`.** The latter (referenced elsewhere in
+  the roadmap) predates bloom #532 and lacks the batch commands. No versioned `bloomcli` release
+  has been cut yet, so the commit-sha tag is the only correct reference for now — expect to bump
+  it again once a real version tag exists.
+- **Credential mount is a reference, not a live dependency.** `bloomctl`'s auth
+  (`bloomcli/src/bloomctl/credentials.py`) reads a dotenv file at `~/.bloom/credentials.txt`
+  directly — no interactive login needs to have run in-process, so a Secret volume mount works with
+  zero `bloomctl` code changes. The actual credential (sleap-roots-pipeline#17) is being provisioned
+  in a parallel session; this change wires the reference and does not block on it.
+- **`HOME=/home/bloom` set explicitly** in both new containers — `bloomcli`'s Dockerfile creates its
+  runtime user via `adduser --system` with no explicit home directory, so `Path.home()` (which
+  `load_credentials()` uses) is ambiguous without it.
+- **Batch input is a Workflow parameter (`scan-ids`), not a per-run isolated path.** Volumes stay
+  the existing fixed `a4_poc` hostPath paths — safe because nothing can submit concurrent batches
+  yet (no trigger route exists to do so). Revisit alongside the Bloom-side dispatch worker.
+- **Capability rename: `per-scan-pipeline` → `per-batch-pipeline`.** Single-scan support isn't
+  removed — it's a batch of size 1 — but keeping the old id would mislead readers into thinking a
+  separate scan-only pathway still exists. The `predictor`/`trait-extractor` requirements carry
+  forward unchanged in substance under the new capability id.
+
+## Out of scope (later changes)
+
+The Argo semaphore for concurrent-batch concurrency (design §9 of the 2026-07-06 doc), per-run path
+isolation, moving off the interim image tag, the dev-personal hostPath convention, the Bloom-side
+trigger route + `cyl_pipeline_runs`/`cyl_pipeline_run_scans` tables + dispatch worker
+(bloom #11/#404), producer Argo-readiness reconciliation (predict #26 / sleap-roots #259), and
+notification (sleap-roots-pipeline#18).
+
+## Risks
+
+- **Credential not yet provisioned.** The Secret reference is correct-by-construction but
+  non-functional until sleap-roots-pipeline#17 lands. Mitigated by not making live-cluster
+  execution a validation target for this change (see `tasks.md`) — `argo lint` + a real local WSL2
+  dry-run (bind-mounting a personal `~/.bloom/credentials.txt`) are the bar to merge.
+- **`--scan-ids ""` (the parameter's empty default) behavior is unverified.** Whether it exits 0 as
+  "empty input" or errors as a CLI parse failure determines whether an unparameterized dry-submit is
+  a safe sanity check — confirmed during the WSL2 dry-run task, not assumed here.

--- a/openspec/changes/add-per-batch-argo-workflow/design.md
+++ b/openspec/changes/add-per-batch-argo-workflow/design.md
@@ -52,13 +52,13 @@ tracked in #21.
 
 ## Risks
 
-- **Credential not yet provisioned.** The Secret reference is correct-by-construction but
-  non-functional until sleap-roots-pipeline#17 lands. Two distinct failure modes are both expected
-  and both fine for this change's acceptance gate: if the `bloom-pipeline-credentials` Secret
-  object doesn't exist at all, the pod fails at volume-mount/admission time (never reaching
-  `bloomctl`); if it exists with placeholder/incomplete values, `bloomctl` itself raises a clean
-  auth error. Either is evidence the wiring is correct, not that it's broken — a real success is
-  possible only once #17 actually lands.
+- **Credential provisioning status.** The `genericsecret-bloom-staging-pipeline-credentials`
+  Secret has since been created via the RunAI console (Credentials → Generic secret, Project
+  scope `talmo-lab`), populated from a `bloomctl login --profile pipeline-staging` against
+  `staging.bloom.salk.edu` — sleap-roots-pipeline#17 is effectively resolved for the staging
+  environment. Not yet verified live: whether the console's value field preserved the full
+  multi-line dotenv content byte-for-byte (only visually confirmed, not diffed against the
+  source file) — task 5's cluster submit is the first real test of that.
 - **`--scan-ids ""` (the parameter's empty default) behavior.** The source implies a clean exit 0
   (`parse_scan_ids_flag("")` → `[]`, "nothing to stage") rather than a CLI parse error, but this is
   confirmed on the real cluster submit (`tasks.md` 5.4), not assumed here.

--- a/openspec/changes/add-per-batch-argo-workflow/design.md
+++ b/openspec/changes/add-per-batch-argo-workflow/design.md
@@ -56,9 +56,18 @@ tracked in #21.
   Secret has since been created via the RunAI console (Credentials → Generic secret, Project
   scope `talmo-lab`), populated from a `bloomctl login --profile pipeline-staging` against
   `staging.bloom.salk.edu` — sleap-roots-pipeline#17 is effectively resolved for the staging
-  environment. Not yet verified live: whether the console's value field preserved the full
-  multi-line dotenv content byte-for-byte (only visually confirmed, not diffed against the
-  source file) — task 5's cluster submit is the first real test of that.
+  environment. **Confirmed live**: the multi-line value survived intact — `images-downloader`
+  authenticated and staged real frames on the first real cluster submit.
+- **Skip-if-done can serve stale copied-through data after an upstream data fix, not just after
+  a code fix.** Found during this change's own cluster testing (bloom #555/#556): when
+  `images-downloader` re-staged scans with a corrected sidecar, `predictor` still skipped
+  re-running (its own prediction outputs were already valid), so it never re-copied the corrected
+  sidecar forward into its output directory — `trait-extractor` kept reading the stale copy until
+  `predictor`'s outputs were manually cleared to force a real re-run. This is a variant of the
+  already-known "existence-only skip" resumability gap (design doc §8 of the 2026-07-06 doc) that
+  specifically affects sidecar *content* changes, not just prediction validity — worth folding into
+  whatever eventually hardens skip-if-done (checksum-verified skip, not just existence), rather than
+  fixed here.
 - **`--scan-ids ""` (the parameter's empty default) behavior.** The source implies a clean exit 0
   (`parse_scan_ids_flag("")` → `[]`, "nothing to stage") rather than a CLI parse error, but this is
   confirmed on the real cluster submit (`tasks.md` 5.4), not assumed here.

--- a/openspec/changes/add-per-batch-argo-workflow/proposal.md
+++ b/openspec/changes/add-per-batch-argo-workflow/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The DAG is still the A4 PoC's hardcoded two-stage `predictor → trait-extractor` flow against one
+fixed, manually pre-staged scan directory. `bloomctl` now has batch-capable stage-in/write-back
+commands (`batch-download-for-predict` / `batch-ingest-result`,
+[bloom #532](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/532)) — this change
+wires them in as the pipeline's missing first and last stages, turning it into a real four-task
+per-batch pipeline: `images-downloader → predictor → trait-extractor → write-back`.
+
+Grounded in the approved design:
+`docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md`.
+
+Deliberately **deferred to later changes**: the Argo semaphore for concurrent-batch concurrency
+(design §9 of `2026-07-06-a4-request-driven-pipeline-design.md`), per-run path isolation (still
+reuses the fixed `a4_poc` hostPath paths), moving off the interim `sha-61959bd` image tag, the
+dev-personal hostPath convention, the Bloom-side trigger route/`cyl_pipeline_runs` tables/dispatch
+worker, producer Argo-readiness reconciliation (predict #26 / sleap-roots #259), and notification
+(#18). This change is the runnable four-stage core, submitted manually via
+`argo submit --parameter scan-ids=...`.
+
+## What Changes
+
+- **Rewrite the DAG** (`sleap-roots-pipeline.yaml`) to four stages: `images-downloader` (root) →
+  `predictor` → `trait-extractor` → `write-back`. Add a `scan-ids` Workflow parameter and a
+  `bloom-credentials` Secret volume. `predictor`/`trait-extractor` templates are unchanged.
+- **New `sleap-roots-images-downloader-template.yaml`**: runs `bloomctl cyl
+  batch-download-for-predict <images-input-dir> --scan-ids {{workflow.parameters.scan-ids}}`,
+  image `ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd`.
+- **New `sleap-roots-write-back-template.yaml`**: runs `bloomctl cyl batch-ingest-result
+  <traits-output-dir> --predictions-dir <predictions-output-dir>`, same image.
+- Both new templates set `HOME=/home/bloom` explicitly (the image's runtime user has no
+  deterministic home dir otherwise) and mount a `bloom-credentials` Secret at
+  `/home/bloom/.bloom/credentials.txt` — a placeholder reference; the actual credential is being
+  provisioned in a parallel `salk-bloom` session (sleap-roots-pipeline#17) and this change does not
+  depend on it landing first.
+- **Launcher** (`runai_run_pipeline.sh`): register the two new template files.
+- **Local parity**: sync `local-WSL2-sleap-roots-pipeline.yaml` to the same four-stage shape
+  (dropping its stale leftover `models-downloader` task, left over from before the cluster side
+  dropped it), add matching `local-WSL2-*-template.yaml` files. Local credentials use a `hostPath`
+  bind-mount of a real `~/.bloom/credentials.txt`, not a Kubernetes Secret, so a WSL2 dry-run can
+  genuinely exercise both new `bloomctl` commands end-to-end.
+
+## Impact
+
+- **New capability:** `per-batch-pipeline` (supersedes `per-scan-pipeline`).
+- **Removed capability:** `per-scan-pipeline` — its two-task/single-hardcoded-scan requirements no
+  longer hold. Single-scan support isn't lost; it's a batch of size 1 through the new pipeline.
+- **Affected code:** `sleap-roots-pipeline.yaml`, two new cluster template files, two new
+  `local-WSL2-*` template files, `local-WSL2-sleap-roots-pipeline.yaml`, `runai_run_pipeline.sh`.
+  `sleap-roots-predictor-template.yaml`/`sleap-roots-trait-extractor-template.yaml` are untouched.
+- **External prerequisites (block a live cluster run, not the manifest change or its validation):**
+  the `bloom-pipeline-credentials` Secret must exist with real values (tracked separately,
+  sleap-roots-pipeline#17, in progress). This change's validation target is `argo lint` + a real
+  local WSL2 dry-run, not a live cluster run — see `tasks.md`.

--- a/openspec/changes/add-per-batch-argo-workflow/proposal.md
+++ b/openspec/changes/add-per-batch-argo-workflow/proposal.md
@@ -57,9 +57,7 @@ and behave identically once reached).
 - **Affected code:** `sleap-roots-pipeline.yaml`, two new cluster template files,
   `runai_run_pipeline.sh`. `sleap-roots-predictor-template.yaml`/
   `sleap-roots-trait-extractor-template.yaml` and all `local-WSL2-*` files are untouched.
-- **External prerequisites (block a fully successful live run, not the manifest change or its
-  validation):** the `bloom-pipeline-credentials` Secret must exist with real values (tracked
-  separately, sleap-roots-pipeline#17, in progress). This change's validation target is `argo lint`
-  + a real submit against the RunAI cluster — see `tasks.md` §5. A clean failure at
-  `images-downloader`'s `bloomctl` auth step is an expected, acceptable outcome for this change;
-  full success requires #17.
+- **External prerequisites:** the `genericsecret-bloom-staging-pipeline-credentials` Secret has
+  been created via the RunAI console (sleap-roots-pipeline#17 resolved for staging), so task 5's
+  cluster submit can now attempt a real, fully successful run rather than just an expected auth
+  failure — see `tasks.md` §5.

--- a/openspec/changes/add-per-batch-argo-workflow/proposal.md
+++ b/openspec/changes/add-per-batch-argo-workflow/proposal.md
@@ -14,9 +14,17 @@ Deliberately **deferred to later changes**: the Argo semaphore for concurrent-ba
 (design §9 of `2026-07-06-a4-request-driven-pipeline-design.md`), per-run path isolation (still
 reuses the fixed `a4_poc` hostPath paths), moving off the interim `sha-61959bd` image tag, the
 dev-personal hostPath convention, the Bloom-side trigger route/`cyl_pipeline_runs` tables/dispatch
-worker, producer Argo-readiness reconciliation (predict #26 / sleap-roots #259), and notification
-(#18). This change is the runnable four-stage core, submitted manually via
+worker, producer Argo-readiness reconciliation (predict #26 / sleap-roots #259), notification
+(#18), and local-WSL2 dev testing for this DAG shape (#21, updated with this change's specifics but
+not implemented here — this machine's Docker Desktop Kubernetes has no GPU resource at all,
+verified live, so `predictor` cannot schedule locally regardless). This change is the runnable
+four-stage core, validated on the real RunAI cluster (see `tasks.md` §5) and submitted manually via
 `argo submit --parameter scan-ids=...`.
+
+**BREAKING**: once merged and redeployed, the currently-working manual `argo submit` flow's DAG
+shape changes — a full run won't succeed past the new `images-downloader` stage until the
+credential from #17 lands (expected, not a regression: `predictor`/`trait-extractor` are unchanged
+and behave identically once reached).
 
 ## What Changes
 
@@ -33,22 +41,25 @@ worker, producer Argo-readiness reconciliation (predict #26 / sleap-roots #259),
   `/home/bloom/.bloom/credentials.txt` — a placeholder reference; the actual credential is being
   provisioned in a parallel `salk-bloom` session (sleap-roots-pipeline#17) and this change does not
   depend on it landing first.
+- **`images-input-dir`'s `hostPath.type`** changes from `Directory` to `DirectoryOrCreate` — it no
+  longer requires a human to have manually pre-staged it; `images-downloader` now writes there
+  automatically, and `type: Directory` would `FailedMount` on a path nothing has staged into yet.
 - **Launcher** (`runai_run_pipeline.sh`): register the two new template files.
-- **Local parity**: sync `local-WSL2-sleap-roots-pipeline.yaml` to the same four-stage shape
-  (dropping its stale leftover `models-downloader` task, left over from before the cluster side
-  dropped it), add matching `local-WSL2-*-template.yaml` files. Local credentials use a `hostPath`
-  bind-mount of a real `~/.bloom/credentials.txt`, not a Kubernetes Secret, so a WSL2 dry-run can
-  genuinely exercise both new `bloomctl` commands end-to-end.
+- **Local WSL2 parity is explicitly out of scope for this change** — see "Why" above. Tracked in
+  #21 (updated, not implemented here). `local-WSL2-sleap-roots-pipeline.yaml` and its template
+  files are untouched.
 
 ## Impact
 
 - **New capability:** `per-batch-pipeline` (supersedes `per-scan-pipeline`).
 - **Removed capability:** `per-scan-pipeline` — its two-task/single-hardcoded-scan requirements no
   longer hold. Single-scan support isn't lost; it's a batch of size 1 through the new pipeline.
-- **Affected code:** `sleap-roots-pipeline.yaml`, two new cluster template files, two new
-  `local-WSL2-*` template files, `local-WSL2-sleap-roots-pipeline.yaml`, `runai_run_pipeline.sh`.
-  `sleap-roots-predictor-template.yaml`/`sleap-roots-trait-extractor-template.yaml` are untouched.
-- **External prerequisites (block a live cluster run, not the manifest change or its validation):**
-  the `bloom-pipeline-credentials` Secret must exist with real values (tracked separately,
-  sleap-roots-pipeline#17, in progress). This change's validation target is `argo lint` + a real
-  local WSL2 dry-run, not a live cluster run — see `tasks.md`.
+- **Affected code:** `sleap-roots-pipeline.yaml`, two new cluster template files,
+  `runai_run_pipeline.sh`. `sleap-roots-predictor-template.yaml`/
+  `sleap-roots-trait-extractor-template.yaml` and all `local-WSL2-*` files are untouched.
+- **External prerequisites (block a fully successful live run, not the manifest change or its
+  validation):** the `bloom-pipeline-credentials` Secret must exist with real values (tracked
+  separately, sleap-roots-pipeline#17, in progress). This change's validation target is `argo lint`
+  + a real submit against the RunAI cluster — see `tasks.md` §5. A clean failure at
+  `images-downloader`'s `bloomctl` auth step is an expected, acceptable outcome for this change;
+  full success requires #17.

--- a/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
+++ b/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
@@ -79,9 +79,11 @@ sourced from predict's manifest.
 ### Requirement: bloomctl-based tasks pin their image and mount credentials deterministically
 
 Both the `images-downloader` and `write-back` templates SHALL pin the `bloomctl` container image by
-immutable tag or digest (never `:latest`), SHALL set a `HOME` environment variable explicitly, and
-SHALL mount a Secret at `$HOME/.bloom/credentials.txt` so `bloomctl`'s credential lookup resolves
-deterministically regardless of the image's runtime user configuration.
+immutable tag or digest (never `:latest`), SHALL set a `HOME` environment variable explicitly, SHALL
+mount a Secret at `$HOME/.bloom/credentials.txt` so `bloomctl`'s credential lookup resolves
+deterministically regardless of the image's runtime user configuration, and SHALL carry the same
+`project: talmo-lab` label the `predictor`/`trait-extractor` templates use for RunAI quota
+attribution.
 
 #### Scenario: Both bloomctl templates pin the image and mount credentials at a fixed HOME path
 
@@ -91,6 +93,7 @@ deterministically regardless of the image's runtime user configuration.
 - **AND** both set a `HOME` environment variable
 - **AND** both mount a Secret volume at `$HOME/.bloom/credentials.txt` (matching the `HOME` value
   they set)
+- **AND** both carry a `project: talmo-lab` label
 
 ### Requirement: Launcher registers all four templates
 

--- a/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
+++ b/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
@@ -82,8 +82,11 @@ Both the `images-downloader` and `write-back` templates SHALL pin the `bloomctl`
 immutable tag or digest (never `:latest`), SHALL set a `HOME` environment variable explicitly, SHALL
 mount a Secret at `$HOME/.bloom/credentials.txt` so `bloomctl`'s credential lookup resolves
 deterministically regardless of the image's runtime user configuration, and SHALL carry the same
-`project: talmo-lab` label the `predictor`/`trait-extractor` templates use for RunAI quota
-attribution.
+`project: talmo-lab` label the `predictor`/`trait-extractor` templates carry, for consistency with
+those templates (note: `sleap-roots-predictor-template.yaml`'s own comment states this exact
+label placement — top-level `WorkflowTemplate.metadata.labels` — is "currently INERT" and is not
+copied onto the pod by Argo; this requirement follows the existing convention rather than
+asserting the label is functionally load-bearing for RunAI quota attribution).
 
 #### Scenario: Both bloomctl templates pin the image and mount credentials at a fixed HOME path
 

--- a/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
+++ b/openspec/changes/add-per-batch-argo-workflow/specs/per-batch-pipeline/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: Four-stage per-batch DAG
+
+The pipeline Workflow SHALL define a four-task DAG: `images-downloader` (root) → `predictor` →
+`trait-extractor` → `write-back`, with each stage depending on the one before it. The Workflow
+SHALL declare a `scan-ids` argument parameter that `images-downloader` consumes, so the batch a run
+processes is a caller-supplied input rather than a hardcoded scan.
+
+#### Scenario: Workflow runs all four stages in order
+
+- **WHEN** the Workflow (`sleap-roots-pipeline.yaml`) is inspected
+- **THEN** its DAG has exactly four tasks: `images-downloader`, `predictor`, `trait-extractor`,
+  `write-back`
+- **AND** `predictor` lists `images-downloader` in its `dependencies`
+- **AND** `trait-extractor` lists `predictor` in its `dependencies`
+- **AND** `write-back` lists `trait-extractor` in its `dependencies`
+- **AND** the Workflow declares a `scan-ids` entry under `arguments.parameters`
+
+### Requirement: Predictor runs the warm GHCR predict container
+
+The `predictor` template SHALL run the rebuilt warm-batch predict container (the
+`sleap-roots-predict` GHCR image), invoked as `<image> <input_dir> <output_dir>` with a
+`WANDB_API_KEY` environment variable sourced from a Kubernetes secret. The template SHALL NOT
+mount a model-input directory (models load in-process from the wandb registry). It SHALL request
+a GPU (`nvidia.com/gpu`) and retain a `retryStrategy`.
+
+#### Scenario: Predictor template uses the GHCR predict image with WANDB key and no models mount
+
+- **WHEN** `sleap-roots-predictor-template.yaml` is inspected
+- **THEN** the container image is the `sleap-roots-predict` GHCR image pinned by digest or `sha-<sha>` (not `:latest`)
+- **AND** its `args` are the input and output directory mount paths only (no models-input argument)
+- **AND** it sets `WANDB_API_KEY` from a `secretKeyRef`
+- **AND** it declares no models-input `volumeMount`
+- **AND** it requests `nvidia.com/gpu`
+
+### Requirement: Trait-extractor runs the GHCR trait-extractor image
+
+The `trait-extractor` template SHALL run `ghcr.io/talmolab/sleap-roots-trait-extractor`, passing
+only the input and output directory paths as `args` (the image's `ENTRYPOINT` is
+`["python","-m","trait_extractor"]`). It SHALL read the predictor's output mount as its input and
+write its results to a separate output mount.
+
+#### Scenario: Trait-extractor template uses the GHCR image via the module entry
+
+- **WHEN** `sleap-roots-trait-extractor-template.yaml` is inspected
+- **THEN** the container image is `ghcr.io/talmolab/sleap-roots-trait-extractor` pinned by digest or `sha-<sha>`
+- **AND** its `args` are exactly the input and output mount paths (no `python /workspace/src/main.py` prefix)
+- **AND** its input mount is the same volume the predictor writes its predictions to
+
+### Requirement: Images-downloader stages a batch via bloomctl
+
+The `images-downloader` template SHALL run `bloomctl cyl batch-download-for-predict` against the
+`images-input-dir` volume, passing the Workflow's `scan-ids` parameter, so `predictor` finds the
+batch already staged in the same layout it reads today.
+
+#### Scenario: Images-downloader template stages the requested batch
+
+- **WHEN** `sleap-roots-images-downloader-template.yaml` is inspected
+- **THEN** its container `args` invoke `cyl batch-download-for-predict` with the `images-input-dir`
+  mount path as the output directory and `--scan-ids {{workflow.parameters.scan-ids}}`
+- **AND** it mounts the same `images-input-dir` volume the `predictor` template mounts
+
+### Requirement: Write-back ingests a batch via bloomctl
+
+The `write-back` template SHALL run `bloomctl cyl batch-ingest-result` against the
+`traits-output-dir` volume with `--predictions-dir` pointed at `predictions-output-dir`, so every
+`ResultEnvelope` `trait-extractor` produces in the batch is written back to Bloom, with blobs
+sourced from predict's manifest.
+
+#### Scenario: Write-back template ingests the batch's envelopes and predictions
+
+- **WHEN** `sleap-roots-write-back-template.yaml` is inspected
+- **THEN** its container `args` invoke `cyl batch-ingest-result` with the `traits-output-dir` mount
+  path as the envelopes directory and `--predictions-dir` set to the `predictions-output-dir` mount
+  path
+- **AND** it mounts both the `traits-output-dir` and `predictions-output-dir` volumes
+
+### Requirement: bloomctl-based tasks pin their image and mount credentials deterministically
+
+Both the `images-downloader` and `write-back` templates SHALL pin the `bloomctl` container image by
+immutable tag or digest (never `:latest`), SHALL set a `HOME` environment variable explicitly, and
+SHALL mount a Secret at `$HOME/.bloom/credentials.txt` so `bloomctl`'s credential lookup resolves
+deterministically regardless of the image's runtime user configuration.
+
+#### Scenario: Both bloomctl templates pin the image and mount credentials at a fixed HOME path
+
+- **WHEN** `sleap-roots-images-downloader-template.yaml` and `sleap-roots-write-back-template.yaml`
+  are inspected
+- **THEN** both pin the `bloomctl` image by an immutable `sha-<sha>` tag or digest, not `:latest`
+- **AND** both set a `HOME` environment variable
+- **AND** both mount a Secret volume at `$HOME/.bloom/credentials.txt` (matching the `HOME` value
+  they set)
+
+### Requirement: Launcher registers all four templates
+
+The cluster launcher (`runai_run_pipeline.sh`) SHALL register the `images-downloader`, `predictor`,
+`trait-extractor`, and `write-back` templates.
+
+#### Scenario: Launcher's TEMPLATES list contains all four stage templates
+
+- **WHEN** `runai_run_pipeline.sh` is inspected
+- **THEN** its registered `TEMPLATES` list contains all four template files: the images-downloader,
+  predictor, trait-extractor, and write-back templates

--- a/openspec/changes/add-per-batch-argo-workflow/specs/per-scan-pipeline/spec.md
+++ b/openspec/changes/add-per-batch-argo-workflow/specs/per-scan-pipeline/spec.md
@@ -1,0 +1,30 @@
+## REMOVED Requirements
+
+### Requirement: Two-stage warm-predict → traits DAG
+
+**Reason**: Superseded by `per-batch-pipeline`'s four-stage DAG
+(`images-downloader → predictor → trait-extractor → write-back`), which adds the automated
+stage-in and write-back tasks this requirement's two-task shape had no room for.
+**Migration**: See `per-batch-pipeline`'s "Four-stage per-batch DAG" requirement.
+
+### Requirement: Predictor runs the warm GHCR predict container
+
+**Reason**: The predictor template's contract is unchanged, but it now belongs to the
+`per-batch-pipeline` capability rather than a capability describing a two-task, single-scan flow.
+**Migration**: Carried forward verbatim as `per-batch-pipeline`'s "Predictor runs the warm GHCR
+predict container" requirement — no behavior change.
+
+### Requirement: Trait-extractor runs the GHCR trait-extractor image
+
+**Reason**: Same as above — contract unchanged, capability renamed.
+**Migration**: Carried forward verbatim as `per-batch-pipeline`'s "Trait-extractor runs the GHCR
+trait-extractor image" requirement — no behavior change.
+
+### Requirement: Producer images are pinned, and the launcher registers only the two templates
+
+**Reason**: The launcher now registers four templates, not two, and image-pinning is now stated
+per bloomctl-based task rather than as a single combined "producer" requirement.
+**Migration**: See `per-batch-pipeline`'s "bloomctl-based tasks pin their image and mount
+credentials deterministically" and "Launcher registers all four templates" requirements. Producer
+image pinning (predict/traits) is preserved unchanged in the carried-forward predictor/
+trait-extractor requirements.

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -6,7 +6,7 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
 
 ## 1. Images-downloader template (new)
 
-- [ ] 1.1 Create `sleap-roots-images-downloader-template.yaml`: image
+- [x] 1.1 Create `sleap-roots-images-downloader-template.yaml`: image
   `ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd`; `args: ["cyl",
   "batch-download-for-predict", "/workspace/images_input", "--scan-ids",
   "{{workflow.parameters.scan-ids}}"]`; `env: [{name: HOME, value: /home/bloom}]`; mounts
@@ -15,51 +15,54 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
   `labels: {project: talmo-lab}` (matches `predictor`/`trait-extractor`'s RunAI quota
   attribution); `priorityClassName: interactive-preemptible`; `retryStrategy` (limit 2); no
   `privileged`/`runAsUser: 0`.
-- [ ] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` → no errors.
-- [ ] 1.3 Inspect the template: confirm the image tag is `sha-61959bd` (not `:latest`), `HOME` is
-  set, the Secret is mounted at exactly `$HOME/.bloom/credentials.txt`, and `labels.project` is
-  `talmo-lab` — matching `per-batch-pipeline`'s "Images-downloader stages a batch via bloomctl" and
-  "bloomctl-based tasks pin their image and mount credentials deterministically" scenarios.
+- [x] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` → **not run**: the
+  `argo` CLI isn't installed in this environment. Substituted a YAML well-formedness check
+  (`python -c "import yaml; yaml.safe_load_all(...)"`) → passed. **Real `argo lint` still needs to
+  run wherever the CLI is available**, alongside task 5's cluster submit.
+- [x] 1.3 Inspected the template (`grep`): image tag is `sha-61959bd`, `HOME` is set, the Secret is
+  mounted at exactly `/home/bloom/.bloom/credentials.txt`, `labels.project` is `talmo-lab` —
+  matches `per-batch-pipeline`'s "Images-downloader stages a batch via bloomctl" and "bloomctl-based
+  tasks pin their image and mount credentials deterministically" scenarios.
 
 ## 2. Write-back template (new)
 
-- [ ] 2.1 Create `sleap-roots-write-back-template.yaml`: same image/env/credential-mount/label
+- [x] 2.1 Create `sleap-roots-write-back-template.yaml`: same image/env/credential-mount/label
   pattern as 1.1; `args: ["cyl", "batch-ingest-result", "/workspace/input", "--predictions-dir",
   "/workspace/predictions"]`; mounts `traits-output-dir` at `/workspace/input` and
   `predictions-output-dir` at `/workspace/predictions`.
-- [ ] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` → no errors.
-- [ ] 2.3 Inspect the template: same checks as 1.3, plus confirm both `traits-output-dir` and
-  `predictions-output-dir` are mounted — matching `per-batch-pipeline`'s "Write-back ingests a
+- [x] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` → **not run** (no `argo` CLI
+  here, same as 1.2); YAML well-formedness check passed. Real `argo lint` still needed.
+- [x] 2.3 Inspected the template: same checks as 1.3, plus confirmed both `traits-output-dir` and
+  `predictions-output-dir` are mounted — matches `per-batch-pipeline`'s "Write-back ingests a
   batch via bloomctl" scenario.
 
 ## 3. DAG rewrite
 
-- [ ] 3.1 Edit `sleap-roots-pipeline.yaml`: add `arguments.parameters: [{name: scan-ids, value:
-  ""}]`; add a `bloom-credentials` Secret volume (`secretName: bloom-pipeline-credentials`); add
-  `images-downloader` as the DAG root and `write-back` as the final task; `predictor` depends on
-  `images-downloader`; `write-back` depends on `trait-extractor`.
-- [ ] 3.2 In the same edit, change `images-input-dir`'s `hostPath.type` from `Directory` to
-  `DirectoryOrCreate`, and update its comment: it no longer requires manual pre-staging —
-  `images-downloader` now writes there automatically, and `type: Directory` would `FailedMount` on
-  a path nothing has staged into yet. `predictions-output-dir`/`traits-output-dir` are otherwise
+- [x] 3.1 Edited `sleap-roots-pipeline.yaml`: added `arguments.parameters: [{name: scan-ids, value:
+  ""}]`; added a `bloom-credentials` Secret volume (`secretName: bloom-pipeline-credentials`);
+  added `images-downloader` as the DAG root and `write-back` as the final task; `predictor` depends
+  on `images-downloader`; `write-back` depends on `trait-extractor`.
+- [x] 3.2 In the same edit, changed `images-input-dir`'s `hostPath.type` from `Directory` to
+  `DirectoryOrCreate`, and updated its comment: it no longer requires manual pre-staging —
+  `images-downloader` now writes there automatically. `predictions-output-dir`/`traits-output-dir`
   unchanged (already `DirectoryOrCreate`).
-- [ ] 3.3 Inspect the DAG's `tasks` list: confirm exactly four tasks and the dependency chain
-  matches `images-downloader → predictor → trait-extractor → write-back` (manifest-field check,
-  matching `per-batch-pipeline`'s "Four-stage per-batch DAG" scenario).
-- [ ] 3.4 Cross-check `templateRef` resolution by hand (offline `argo lint` cannot catch a
-  name/field mismatch here — it only validates each file's own schema): diff the two new tasks'
-  `templateRef.name`/`template` values in `sleap-roots-pipeline.yaml` against the `metadata.name`/
-  `spec.templates[].name` actually set in `sleap-roots-images-downloader-template.yaml` and
-  `sleap-roots-write-back-template.yaml`. Confirm exact string matches.
-- [ ] 3.5 `argo lint --offline sleap-roots-pipeline.yaml` → no errors (note: doesn't cross-resolve
-  `templateRef`s — that's what 3.4 and task 6 are for).
+- [x] 3.3 Inspected the DAG's `tasks` list (`grep`): exactly four tasks, dependency chain matches
+  `images-downloader → predictor → trait-extractor → write-back` — matches `per-batch-pipeline`'s
+  "Four-stage per-batch DAG" scenario.
+- [x] 3.4 Cross-checked `templateRef` resolution by hand: both new tasks'
+  `templateRef.name`/`template` values in `sleap-roots-pipeline.yaml` exactly match the
+  `metadata.name`/`spec.templates[].name` set in `sleap-roots-images-downloader-template.yaml` and
+  `sleap-roots-write-back-template.yaml` — confirmed via `grep`, no mismatch.
+- [x] 3.5 `argo lint --offline sleap-roots-pipeline.yaml` → **not run** (no `argo` CLI here); YAML
+  well-formedness check passed. Real `argo lint` still needed (doesn't cross-resolve `templateRef`s
+  anyway — 3.4 covers that).
 
 ## 4. Launcher
 
-- [ ] 4.1 Edit `runai_run_pipeline.sh`: add `sleap-roots-images-downloader-template.yaml` and
+- [x] 4.1 Edited `runai_run_pipeline.sh`: added `sleap-roots-images-downloader-template.yaml` and
   `sleap-roots-write-back-template.yaml` to the registered `TEMPLATES` list.
-- [ ] 4.2 Inspect `TEMPLATES`: confirm it lists all four template files (matching
-  `per-batch-pipeline`'s "Launcher registers all four templates" scenario).
+- [x] 4.2 Inspected `TEMPLATES` (`grep`): lists all four template files, `bash -n` syntax-clean —
+  matches `per-batch-pipeline`'s "Launcher registers all four templates" scenario.
 
 ## 5. Real cluster submit (primary acceptance gate — no local dry-run, see below)
 
@@ -88,8 +91,11 @@ directly against the real RunAI cluster instead.
 
 ## 6. Validate + close out
 
-- [ ] 6.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
-- [ ] 6.2 Re-lint all touched/new cluster manifests offline, clean.
+- [x] 6.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
+- [x] 6.2 Re-lint all touched/new cluster manifests: real `argo lint` unavailable in this
+  environment (no `argo` CLI installed) — substituted a YAML well-formedness check on all 3
+  touched/new files + `bash -n` on the launcher; all clean. **Real `argo lint` still needs to run**
+  wherever the CLI is available, ideally alongside task 5's cluster submit.
 - [ ] 6.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
   change-id. Note: this change replaces the working manual `argo submit` flow's DAG shape —
   **BREAKING** in the sense that a full run won't succeed past `images-downloader` until #17's

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -1,0 +1,83 @@
+# Tasks
+
+Declarative repo — a task's "test" is `argo lint`, a manifest-field inspection, or a WSL2 dry-run
+(no pytest). Full rationale + deferred items in `design.md` and
+`docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md`.
+
+## 1. Images-downloader template (new)
+
+- [ ] 1.1 Create `sleap-roots-images-downloader-template.yaml`: image
+  `ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd`; `args: ["cyl",
+  "batch-download-for-predict", "/workspace/images_input", "--scan-ids",
+  "{{workflow.parameters.scan-ids}}"]`; `env: [{name: HOME, value: /home/bloom}]`; mounts
+  `images-input-dir` at `/workspace/images_input` and a `bloom-credentials` Secret at
+  `/home/bloom/.bloom/credentials.txt` (`subPath: credentials.txt`, `readOnly: true`);
+  `priorityClassName: interactive-preemptible`; `retryStrategy` (limit 2); no
+  `privileged`/`runAsUser: 0`.
+- [ ] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` → no errors.
+
+## 2. Write-back template (new)
+
+- [ ] 2.1 Create `sleap-roots-write-back-template.yaml`: same image/env/credential-mount pattern as
+  1.1; `args: ["cyl", "batch-ingest-result", "/workspace/input", "--predictions-dir",
+  "/workspace/predictions"]`; mounts `traits-output-dir` at `/workspace/input` and
+  `predictions-output-dir` at `/workspace/predictions`.
+- [ ] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` → no errors.
+
+## 3. DAG rewrite
+
+- [ ] 3.1 Edit `sleap-roots-pipeline.yaml`: add `arguments.parameters: [{name: scan-ids, value:
+  ""}]`; add a `bloom-credentials` Secret volume (`secretName: bloom-pipeline-credentials`); add
+  `images-downloader` as the DAG root and `write-back` as the final task; `predictor` depends on
+  `images-downloader`; `write-back` depends on `trait-extractor`. Existing `images-input-dir`/
+  `predictions-output-dir`/`traits-output-dir` hostPath volumes unchanged.
+- [ ] 3.2 Inspect the DAG's `tasks` list: confirm exactly four tasks and the dependency chain
+  matches `images-downloader → predictor → trait-extractor → write-back` (manifest-field check,
+  matching `per-batch-pipeline`'s "Four-stage per-batch DAG" scenario).
+- [ ] 3.3 `argo lint --offline sleap-roots-pipeline.yaml` → no errors (note: offline lint cannot
+  cross-resolve `templateRef`s against unregistered `WorkflowTemplate` files — full cross-resolution
+  happens after `argo template create`/`kubectl apply`, in task 6).
+
+## 4. Launcher
+
+- [ ] 4.1 Edit `runai_run_pipeline.sh`: add `sleap-roots-images-downloader-template.yaml` and
+  `sleap-roots-write-back-template.yaml` to the registered `TEMPLATES` list.
+- [ ] 4.2 Inspect `TEMPLATES`: confirm it lists all four template files (matching
+  `per-batch-pipeline`'s "Launcher registers all four templates" scenario).
+
+## 5. Local WSL2 parity
+
+- [ ] 5.1 Edit `local-WSL2-sleap-roots-pipeline.yaml`: drop the stale leftover `models-downloader`
+  task and its `models-input-dir`/`models-output-dir` volumes (left over from before the cluster
+  side dropped this stage); add `images-downloader`/`write-back` tasks matching the cluster DAG's
+  dependency chain; add the `scan-ids` parameter.
+- [ ] 5.2 Create `local-WSL2-sleap-roots-images-downloader-template.yaml` and
+  `local-WSL2-sleap-roots-write-back-template.yaml`: same `bloomctl` image/args as the cluster
+  templates, but the credential volume is a `hostPath` bind-mount of a real local
+  `~/.bloom/credentials.txt` (not a Kubernetes Secret) — mirror `mount/path parity, not template
+  names`, per this repo's own local-vs-cluster convention (`openspec/project.md`).
+- [ ] 5.3 `argo lint --offline` on both new local template files and the edited local pipeline file
+  → no errors.
+
+## 6. Real local WSL2 dry-run (primary acceptance gate)
+
+- [ ] 6.1 Register the four local templates (`kubectl apply -f <file> -n argo` per
+  `local_run_pipeline_first_time.sh`'s existing pattern) and confirm `images-downloader` actually
+  authenticates using the bind-mounted `~/.bloom/credentials.txt` and stages real frames for a real
+  scan-id.
+- [ ] 6.2 Submit the local Workflow with a real `scan-ids` value (`argo submit
+  local-WSL2-sleap-roots-pipeline.yaml --parameter scan-ids=<real-scan-id> -n argo`); confirm all
+  four DAG nodes go green and `write-back` reports a successful (or idempotent-skip) ingest.
+  Record the run result here once done.
+- [ ] 6.3 Separately, confirm `batch-download-for-predict --scan-ids ""` (the parameter's empty
+  default) behaves as "empty input → exit 0," not a CLI parse error — determines whether an
+  unparameterized dry-submit is a safe sanity check going forward. Note the actual behavior found.
+
+## 7. Validate + close out
+
+- [ ] 7.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
+- [ ] 7.2 Re-lint all touched/new manifests (cluster + local) offline, clean.
+- [ ] 7.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
+  change-id; note the WSL2 dry-run result; leave the deferred items (semaphore, per-run path
+  isolation, image-tag lifecycle, dev-personal hostPath, Bloom trigger route, producer
+  Argo-readiness, notification) tracked, not silently dropped.

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -110,9 +110,30 @@ directly against the real RunAI cluster instead.
     root-cause analysis. **This change's own scope (the Argo DAG wiring) is fully validated up
     through `predictor`** — `write-back` can't be exercised with real data until #555 is fixed
     upstream; that's an external blocker, not a defect here.
-- [ ] 5.4 Not run — descoped once #555 blocked reaching `write-back` for real. `--scan-ids ""`
-  behavior is already known from source (`parse_scan_ids_flag("")` → `[]` → exit 0) per the
-  design doc's Risks section; worth a real confirmation once #555 unblocks a full-batch test.
+- [x] 5.4 **#555 fixed upstream** ([bloom #556](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/556),
+  merged to staging, commit `c21d11b`) — `build_sidecar()` now constructs a real
+  `sleap_roots_contracts.InputRef` (str-cast `image_ids`), and `scan_is_already_staged()` now
+  rejects pre-fix int-typed sidecars so already-staged scans re-stage cleanly. Bumped the image
+  pin in both new templates from `sha-61959bd` to `sha-c21d11b` (verified via the actual
+  `docker-build-bloomcli` workflow run for that commit, not assumed).
+  **Resubmitted `scan-ids=289,577,1009`**: `images-downloader` re-staged all 3 scans fresh
+  (`Staged 3/3 scans`, correctly detecting the old int-typed sidecars as invalid);
+  `predictor` skipped (valid predictions already existed from the earlier run) — **but this meant
+  it never re-copied the fixed sidecar forward into its own output directory** (predict's
+  copy-through only happens when it actually re-runs), so `trait-extractor` initially failed
+  identically again, reading the stale sidecar copy still sitting in `predictions-output-dir`. A
+  real, previously-undocumented interaction between the skip-if-done design and an upstream data
+  fix — worth flagging in `design.md`'s risks (see below). Fixed by clearing the 3 scans' existing
+  outputs from `predictions-output-dir` (forcing a real re-predict + fresh sidecar copy-through),
+  then resubmitting.
+  **Result: `sleap-roots-pipeline-v4lg7` — `Status: Succeeded`, `Progress: 4/4`, all four stages
+  green** (images-downloader 6s, predictor 2m, trait-extractor 12s, write-back 8s). Confirmed the
+  write-back was real (not just exit 0) by manually re-`ingest-result`-ing all 3 result envelopes
+  via `bloomctl` — each returned `"was_noop": true"` with real `source_id`s (6, 7, 8), Bloom's
+  actual idempotent first-writer-wins response, proving the original write-back created real
+  `cyl_trait_sources` rows in the staging database. **This is the first fully-real end-to-end A4
+  run.** `--scan-ids ""` behavior (the original point of this task) still not separately confirmed
+  — low priority now that the real batch path is proven; can be checked opportunistically.
 
 ## 6. Validate + close out
 
@@ -120,12 +141,13 @@ directly against the real RunAI cluster instead.
 - [x] 6.2 Re-linted all touched/new cluster manifests via WSL's `argo` CLI (v3.6.5) + `bash -n` on
   the launcher: both new templates lint clean; `sleap-roots-pipeline.yaml` hits the expected
   unregistered-`templateRef` error only (see 3.5) — no other issues.
-- [ ] 6.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
-  change-id. Note: this change replaces the working manual `argo submit` flow's DAG shape —
-  **BREAKING** in the sense that a full run won't succeed past `images-downloader` until #17's
-  credential lands (expected, not a regression — `predictor`/`trait-extractor` themselves are
-  unchanged and still work identically once reached). Note the task 5 cluster-submit result, the
-  updated issue #21, and leave the other deferred items (semaphore, per-run path isolation,
+- [x] 6.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
+  change-id. This change replaces the working manual `argo submit` flow's DAG shape — **BREAKING**
+  in that sense, though by the time task 5 completed, a full run actually succeeds end-to-end
+  (#17's credential resolved, #555/#556 fixed upstream) — `predictor`/`trait-extractor` themselves
+  are unchanged and behave identically to before, now reached by two new real stages. Noted the
+  task 5 cluster-submit result (full success, `source_id`s 6/7/8), the updated issue #21, the new
+  bloom #555/#556 references, and left the other deferred items (semaphore, per-run path isolation,
   image-tag lifecycle, dev-personal hostPath, Bloom trigger route, producer Argo-readiness,
-  notification, empty-batch silent-green risk shared with trait-extractor/sleap-roots#259) tracked,
-  not silently dropped.
+  notification, empty-batch silent-green risk shared with trait-extractor/sleap-roots#259, and the
+  newly-found stale-sidecar-copy-through risk) tracked, not silently dropped.

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -15,10 +15,9 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
   `labels: {project: talmo-lab}` (matches `predictor`/`trait-extractor`'s RunAI quota
   attribution); `priorityClassName: interactive-preemptible`; `retryStrategy` (limit 2); no
   `privileged`/`runAsUser: 0`.
-- [x] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` → **not run**: the
-  `argo` CLI isn't installed in this environment. Substituted a YAML well-formedness check
-  (`python -c "import yaml; yaml.safe_load_all(...)"`) → passed. **Real `argo lint` still needs to
-  run wherever the CLI is available**, alongside task 5's cluster submit.
+- [x] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` (run via WSL, where the
+  `argo` CLI actually lives per the `runai` skill — not on Windows Git Bash PATH) → ✔ no linting
+  errors found.
 - [x] 1.3 Inspected the template (`grep`): image tag is `sha-61959bd`, `HOME` is set, the Secret is
   mounted at exactly `/home/bloom/.bloom/credentials.txt`, `labels.project` is `talmo-lab` —
   matches `per-batch-pipeline`'s "Images-downloader stages a batch via bloomctl" and "bloomctl-based
@@ -30,8 +29,8 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
   pattern as 1.1; `args: ["cyl", "batch-ingest-result", "/workspace/input", "--predictions-dir",
   "/workspace/predictions"]`; mounts `traits-output-dir` at `/workspace/input` and
   `predictions-output-dir` at `/workspace/predictions`.
-- [x] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` → **not run** (no `argo` CLI
-  here, same as 1.2); YAML well-formedness check passed. Real `argo lint` still needed.
+- [x] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` (via WSL) → ✔ no linting
+  errors found.
 - [x] 2.3 Inspected the template: same checks as 1.3, plus confirmed both `traits-output-dir` and
   `predictions-output-dir` are mounted — matches `per-batch-pipeline`'s "Write-back ingests a
   batch via bloomctl" scenario.
@@ -53,9 +52,13 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
   `templateRef.name`/`template` values in `sleap-roots-pipeline.yaml` exactly match the
   `metadata.name`/`spec.templates[].name` set in `sleap-roots-images-downloader-template.yaml` and
   `sleap-roots-write-back-template.yaml` — confirmed via `grep`, no mismatch.
-- [x] 3.5 `argo lint --offline sleap-roots-pipeline.yaml` → **not run** (no `argo` CLI here); YAML
-  well-formedness check passed. Real `argo lint` still needed (doesn't cross-resolve `templateRef`s
-  anyway — 3.4 covers that).
+- [x] 3.5 `argo lint --offline sleap-roots-pipeline.yaml` (via WSL) → 1 error:
+  `templates.pipeline.tasks.images-downloader couldn't find workflow template
+  "sleap-roots-images-downloader-template" in namespace "runai-talmo-lab"`. This is the same known
+  limitation the archived `add-per-scan-argo-workflow` change documented (offline lint can't
+  cross-resolve `templateRef`s against a namespace where the templates aren't registered) — not a
+  new bug; 3.4's manual name cross-check already confirmed the reference is correct. Full
+  cross-resolution happens after `argo template create`/`update`, in task 5.
 
 ## 4. Launcher
 
@@ -92,10 +95,9 @@ directly against the real RunAI cluster instead.
 ## 6. Validate + close out
 
 - [x] 6.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
-- [x] 6.2 Re-lint all touched/new cluster manifests: real `argo lint` unavailable in this
-  environment (no `argo` CLI installed) — substituted a YAML well-formedness check on all 3
-  touched/new files + `bash -n` on the launcher; all clean. **Real `argo lint` still needs to run**
-  wherever the CLI is available, ideally alongside task 5's cluster submit.
+- [x] 6.2 Re-linted all touched/new cluster manifests via WSL's `argo` CLI (v3.6.5) + `bash -n` on
+  the launcher: both new templates lint clean; `sleap-roots-pipeline.yaml` hits the expected
+  unregistered-`templateRef` error only (see 3.5) — no other issues.
 - [ ] 6.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
   change-id. Note: this change replaces the working manual `argo submit` flow's DAG shape —
   **BREAKING** in the sense that a full run won't succeed past `images-downloader` until #17's

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -80,23 +80,39 @@ variants are also already known-stale relative to the cluster's GHCR contract (t
 issue #21 — updated with this change's specifics, not touched here). This change validates
 directly against the real RunAI cluster instead.
 
-- [ ] 5.1 Register all four templates on the cluster via `runai_run_pipeline.sh` (or `argo
-  template create`/`update` directly, per the script's own documented Kubernetes-mode fallback).
-- [ ] 5.2 Submit with **two or more** real `scan-ids` (comma-separated) — not a single scan — to
-  actually exercise batch behavior, since that's the point of this change. `argo submit
-  sleap-roots-pipeline.yaml --parameter scan-ids=<id1>,<id2> -n runai-talmo-lab`.
-- [ ] 5.3 Confirm the DAG structure resolves correctly at submit time (proves 3.4's cross-check was
-  right) and `images-downloader` schedules and starts. The `genericsecret-
-  bloom-staging-pipeline-credentials` Secret now exists with real values (sleap-roots-pipeline#17
-  resolved for staging), so a **full successful run is the expected outcome** — confirm
-  `images-downloader` actually authenticates and stages real frames. If it instead fails at the
-  `bloomctl` auth step, that's a real bug to investigate (e.g. the RunAI console's multi-line value
-  got mangled, or the `secretName`/key don't actually match what the console produced), not an
-  expected gap. Record the actual result either way.
-- [ ] 5.4 Confirm `batch-download-for-predict --scan-ids ""` (the parameter's empty default)
-  behavior matches what the source implies (`parse_scan_ids_flag("")` → `[]` → exit 0, "nothing to
-  stage," not a CLI parse error) — submit once with no `scan-ids` override and record the actual
-  result. This determines whether an unparameterized submit is a safe no-op going forward.
+- [x] 5.1 Registered all four templates on the cluster via `argo template create`/`update`
+  (Kubernetes-mode, `argo-user` WSL kubeconfig — confirmed via `kubectl auth can-i` that this
+  identity can create/update Workflows and WorkflowTemplates, same as the archived PoC's task 6.1).
+- [x] 5.2 Submitted with real `scan-ids` — first `1,289,577,1009` (4 real staged scans, ages
+  0/2/7/9 days), then `289,577,1009` after excluding `scan_1` (see 5.3). Real batch behavior
+  exercised, not a single scan.
+- [x] 5.3 **DAG structure and `templateRef` resolution confirmed correct** — non-offline `argo
+  lint` against the live cluster passed clean once templates were registered; `images-downloader`
+  scheduled and started immediately. **The `genericsecret-bloom-staging-pipeline-credentials`
+  Secret works end-to-end**: `images-downloader` authenticated for real and staged all requested
+  scans (`Staged 4/4 scans`, then `Staged 0/3 scans (3 skipped)` — correct skip-if-done on the
+  second submit). `predictor` also succeeded cleanly on the real 3-scan batch (21s, all inference
+  completed). Two real findings surfaced, both external to this change's own scope:
+  - `scan_1` (age=0 days) hit `ValueError: no models resolved for params {'species': 'canola',
+    'mode': 'cylinder', 'age': 0}` — no production model covers age 0. A genuine data/model-
+    coverage gap, not a wiring defect; excluded from the second submit.
+  - The shared, non-isolated `a4_poc` input path (a known, already-documented deferred limitation
+    of this change — see `design.md`) had leftover scans (`scan_1` from the first submit, plus the
+    old `scan_6791737` PoC reference) that `predictor`'s `run_batch` re-discovered and re-processed
+    on the second submit even though they weren't in `--parameter scan-ids`, since predict scans
+    the whole directory rather than the requested list. Cleaned manually via the `Z:` network
+    drive before the final submit. Confirms the deferred per-run-isolation gap is real, not just
+    theoretical.
+  - `trait-extractor` then failed identically on all 3 real scans — a confirmed, reproducible bug
+    in `bloomctl`'s shared `build_sidecar()` (writes `image_ids` as int; `ScanMetadata` requires
+    str), present since bloom #458, not a #532/this-change regression. Filed as
+    [bloom #555](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/555) with full
+    root-cause analysis. **This change's own scope (the Argo DAG wiring) is fully validated up
+    through `predictor`** — `write-back` can't be exercised with real data until #555 is fixed
+    upstream; that's an external blocker, not a defect here.
+- [ ] 5.4 Not run — descoped once #555 blocked reaching `write-back` for real. `--scan-ids ""`
+  behavior is already known from source (`parse_scan_ids_flag("")` → `[]` → exit 0) per the
+  design doc's Risks section; worth a real confirmation once #555 unblocks a full-batch test.
 
 ## 6. Validate + close out
 

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -129,9 +129,13 @@ directly against the real RunAI cluster instead.
   **Result: `sleap-roots-pipeline-v4lg7` — `Status: Succeeded`, `Progress: 4/4`, all four stages
   green** (images-downloader 6s, predictor 2m, trait-extractor 12s, write-back 8s). Confirmed the
   write-back was real (not just exit 0) by manually re-`ingest-result`-ing all 3 result envelopes
-  via `bloomctl` — each returned `"was_noop": true"` with real `source_id`s (6, 7, 8), Bloom's
+  via `bloomctl` — each returned `"was_noop": true` with real `source_id`s (6, 7, 8), Bloom's
   actual idempotent first-writer-wins response, proving the original write-back created real
-  `cyl_trait_sources` rows in the staging database. **This is the first fully-real end-to-end A4
+  `cyl_trait_sources` rows in the staging database. (Note: this re-verification used the singular
+  `cyl ingest-result` command as a proxy — both it and the actually-wired-in `cyl
+  batch-ingest-result` share the same underlying RPC `was_noop` signal, but `batch-ingest-result`'s
+  own per-item JSON response — `{scan_key, status, error}`, not a bare `was_noop` boolean — was
+  never directly observed in this test.) **This is the first fully-real end-to-end A4
   run.** `--scan-ids ""` behavior (the original point of this task) still not separately confirmed
   — low priority now that the real batch path is proven; can be checked opportunistically.
 

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -1,8 +1,8 @@
 # Tasks
 
-Declarative repo — a task's "test" is `argo lint`, a manifest-field inspection, or a WSL2 dry-run
-(no pytest). Full rationale + deferred items in `design.md` and
-`docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md`.
+Declarative repo — a task's "test" is `argo lint`, a manifest-field inspection, or a real cluster
+submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale + deferred items in
+`design.md` and `docs/superpowers/specs/2026-07-28-a4-batch-stage-write-back-design.md`.
 
 ## 1. Images-downloader template (new)
 
@@ -12,31 +12,47 @@ Declarative repo — a task's "test" is `argo lint`, a manifest-field inspection
   "{{workflow.parameters.scan-ids}}"]`; `env: [{name: HOME, value: /home/bloom}]`; mounts
   `images-input-dir` at `/workspace/images_input` and a `bloom-credentials` Secret at
   `/home/bloom/.bloom/credentials.txt` (`subPath: credentials.txt`, `readOnly: true`);
-  `priorityClassName: interactive-preemptible`; `retryStrategy` (limit 2); no
+  `labels: {project: talmo-lab}` (matches `predictor`/`trait-extractor`'s RunAI quota
+  attribution); `priorityClassName: interactive-preemptible`; `retryStrategy` (limit 2); no
   `privileged`/`runAsUser: 0`.
 - [ ] 1.2 `argo lint --offline sleap-roots-images-downloader-template.yaml` → no errors.
+- [ ] 1.3 Inspect the template: confirm the image tag is `sha-61959bd` (not `:latest`), `HOME` is
+  set, the Secret is mounted at exactly `$HOME/.bloom/credentials.txt`, and `labels.project` is
+  `talmo-lab` — matching `per-batch-pipeline`'s "Images-downloader stages a batch via bloomctl" and
+  "bloomctl-based tasks pin their image and mount credentials deterministically" scenarios.
 
 ## 2. Write-back template (new)
 
-- [ ] 2.1 Create `sleap-roots-write-back-template.yaml`: same image/env/credential-mount pattern as
-  1.1; `args: ["cyl", "batch-ingest-result", "/workspace/input", "--predictions-dir",
+- [ ] 2.1 Create `sleap-roots-write-back-template.yaml`: same image/env/credential-mount/label
+  pattern as 1.1; `args: ["cyl", "batch-ingest-result", "/workspace/input", "--predictions-dir",
   "/workspace/predictions"]`; mounts `traits-output-dir` at `/workspace/input` and
   `predictions-output-dir` at `/workspace/predictions`.
 - [ ] 2.2 `argo lint --offline sleap-roots-write-back-template.yaml` → no errors.
+- [ ] 2.3 Inspect the template: same checks as 1.3, plus confirm both `traits-output-dir` and
+  `predictions-output-dir` are mounted — matching `per-batch-pipeline`'s "Write-back ingests a
+  batch via bloomctl" scenario.
 
 ## 3. DAG rewrite
 
 - [ ] 3.1 Edit `sleap-roots-pipeline.yaml`: add `arguments.parameters: [{name: scan-ids, value:
   ""}]`; add a `bloom-credentials` Secret volume (`secretName: bloom-pipeline-credentials`); add
   `images-downloader` as the DAG root and `write-back` as the final task; `predictor` depends on
-  `images-downloader`; `write-back` depends on `trait-extractor`. Existing `images-input-dir`/
-  `predictions-output-dir`/`traits-output-dir` hostPath volumes unchanged.
-- [ ] 3.2 Inspect the DAG's `tasks` list: confirm exactly four tasks and the dependency chain
+  `images-downloader`; `write-back` depends on `trait-extractor`.
+- [ ] 3.2 In the same edit, change `images-input-dir`'s `hostPath.type` from `Directory` to
+  `DirectoryOrCreate`, and update its comment: it no longer requires manual pre-staging —
+  `images-downloader` now writes there automatically, and `type: Directory` would `FailedMount` on
+  a path nothing has staged into yet. `predictions-output-dir`/`traits-output-dir` are otherwise
+  unchanged (already `DirectoryOrCreate`).
+- [ ] 3.3 Inspect the DAG's `tasks` list: confirm exactly four tasks and the dependency chain
   matches `images-downloader → predictor → trait-extractor → write-back` (manifest-field check,
   matching `per-batch-pipeline`'s "Four-stage per-batch DAG" scenario).
-- [ ] 3.3 `argo lint --offline sleap-roots-pipeline.yaml` → no errors (note: offline lint cannot
-  cross-resolve `templateRef`s against unregistered `WorkflowTemplate` files — full cross-resolution
-  happens after `argo template create`/`kubectl apply`, in task 6).
+- [ ] 3.4 Cross-check `templateRef` resolution by hand (offline `argo lint` cannot catch a
+  name/field mismatch here — it only validates each file's own schema): diff the two new tasks'
+  `templateRef.name`/`template` values in `sleap-roots-pipeline.yaml` against the `metadata.name`/
+  `spec.templates[].name` actually set in `sleap-roots-images-downloader-template.yaml` and
+  `sleap-roots-write-back-template.yaml`. Confirm exact string matches.
+- [ ] 3.5 `argo lint --offline sleap-roots-pipeline.yaml` → no errors (note: doesn't cross-resolve
+  `templateRef`s — that's what 3.4 and task 6 are for).
 
 ## 4. Launcher
 
@@ -45,39 +61,41 @@ Declarative repo — a task's "test" is `argo lint`, a manifest-field inspection
 - [ ] 4.2 Inspect `TEMPLATES`: confirm it lists all four template files (matching
   `per-batch-pipeline`'s "Launcher registers all four templates" scenario).
 
-## 5. Local WSL2 parity
+## 5. Real cluster submit (primary acceptance gate — no local dry-run, see below)
 
-- [ ] 5.1 Edit `local-WSL2-sleap-roots-pipeline.yaml`: drop the stale leftover `models-downloader`
-  task and its `models-input-dir`/`models-output-dir` volumes (left over from before the cluster
-  side dropped this stage); add `images-downloader`/`write-back` tasks matching the cluster DAG's
-  dependency chain; add the `scan-ids` parameter.
-- [ ] 5.2 Create `local-WSL2-sleap-roots-images-downloader-template.yaml` and
-  `local-WSL2-sleap-roots-write-back-template.yaml`: same `bloomctl` image/args as the cluster
-  templates, but the credential volume is a `hostPath` bind-mount of a real local
-  `~/.bloom/credentials.txt` (not a Kubernetes Secret) — mirror `mount/path parity, not template
-  names`, per this repo's own local-vs-cluster convention (`openspec/project.md`).
-- [ ] 5.3 `argo lint --offline` on both new local template files and the edited local pipeline file
-  → no errors.
+**Why not a local WSL2 dry-run:** checked live — this machine's Docker Desktop Kubernetes node
+(`desktop-control-plane`) has no `nvidia.com/gpu` in its `allocatable`/`capacity` at all, so
+`predictor` cannot schedule locally regardless of anything this change does. The `local-WSL2-*`
+variants are also already known-stale relative to the cluster's GHCR contract (tracked separately,
+issue #21 — updated with this change's specifics, not touched here). This change validates
+directly against the real RunAI cluster instead.
 
-## 6. Real local WSL2 dry-run (primary acceptance gate)
+- [ ] 5.1 Register all four templates on the cluster via `runai_run_pipeline.sh` (or `argo
+  template create`/`update` directly, per the script's own documented Kubernetes-mode fallback).
+- [ ] 5.2 Submit with **two or more** real `scan-ids` (comma-separated) — not a single scan — to
+  actually exercise batch behavior, since that's the point of this change. `argo submit
+  sleap-roots-pipeline.yaml --parameter scan-ids=<id1>,<id2> -n runai-talmo-lab`.
+- [ ] 5.3 Confirm the DAG structure resolves correctly at submit time (proves 3.4's cross-check was
+  right) and `images-downloader` schedules and starts. Its `bloomctl` auth is **expected to fail**
+  until the credential from sleap-roots-pipeline#17 lands (tracked separately, in progress) — a
+  clean `bloomctl` auth error here means the wiring is correct, not broken. If the credential
+  happens to be ready by test time, confirm a full successful run instead. Record which outcome
+  actually happened.
+- [ ] 5.4 Confirm `batch-download-for-predict --scan-ids ""` (the parameter's empty default)
+  behavior matches what the source implies (`parse_scan_ids_flag("")` → `[]` → exit 0, "nothing to
+  stage," not a CLI parse error) — submit once with no `scan-ids` override and record the actual
+  result. This determines whether an unparameterized submit is a safe no-op going forward.
 
-- [ ] 6.1 Register the four local templates (`kubectl apply -f <file> -n argo` per
-  `local_run_pipeline_first_time.sh`'s existing pattern) and confirm `images-downloader` actually
-  authenticates using the bind-mounted `~/.bloom/credentials.txt` and stages real frames for a real
-  scan-id.
-- [ ] 6.2 Submit the local Workflow with a real `scan-ids` value (`argo submit
-  local-WSL2-sleap-roots-pipeline.yaml --parameter scan-ids=<real-scan-id> -n argo`); confirm all
-  four DAG nodes go green and `write-back` reports a successful (or idempotent-skip) ingest.
-  Record the run result here once done.
-- [ ] 6.3 Separately, confirm `batch-download-for-predict --scan-ids ""` (the parameter's empty
-  default) behaves as "empty input → exit 0," not a CLI parse error — determines whether an
-  unparameterized dry-submit is a safe sanity check going forward. Note the actual behavior found.
+## 6. Validate + close out
 
-## 7. Validate + close out
-
-- [ ] 7.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
-- [ ] 7.2 Re-lint all touched/new manifests (cluster + local) offline, clean.
-- [ ] 7.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
-  change-id; note the WSL2 dry-run result; leave the deferred items (semaphore, per-run path
-  isolation, image-tag lifecycle, dev-personal hostPath, Bloom trigger route, producer
-  Argo-readiness, notification) tracked, not silently dropped.
+- [ ] 6.1 `openspec validate add-per-batch-argo-workflow --strict` → valid.
+- [ ] 6.2 Re-lint all touched/new cluster manifests offline, clean.
+- [ ] 6.3 `/pr-description`; open PR referencing A4 EPIC (talmolab/sleap-roots-pipeline#10) and this
+  change-id. Note: this change replaces the working manual `argo submit` flow's DAG shape —
+  **BREAKING** in the sense that a full run won't succeed past `images-downloader` until #17's
+  credential lands (expected, not a regression — `predictor`/`trait-extractor` themselves are
+  unchanged and still work identically once reached). Note the task 5 cluster-submit result, the
+  updated issue #21, and leave the other deferred items (semaphore, per-run path isolation,
+  image-tag lifecycle, dev-personal hostPath, Bloom trigger route, producer Argo-readiness,
+  notification, empty-batch silent-green risk shared with trait-extractor/sleap-roots#259) tracked,
+  not silently dropped.

--- a/openspec/changes/add-per-batch-argo-workflow/tasks.md
+++ b/openspec/changes/add-per-batch-argo-workflow/tasks.md
@@ -38,9 +38,13 @@ submit (no pytest, no local WSL2 dry-run — see task 6 for why). Full rationale
 ## 3. DAG rewrite
 
 - [x] 3.1 Edited `sleap-roots-pipeline.yaml`: added `arguments.parameters: [{name: scan-ids, value:
-  ""}]`; added a `bloom-credentials` Secret volume (`secretName: bloom-pipeline-credentials`);
-  added `images-downloader` as the DAG root and `write-back` as the final task; `predictor` depends
-  on `images-downloader`; `write-back` depends on `trait-extractor`.
+  ""}]`; added a `bloom-credentials` Secret volume (`secretName:
+  genericsecret-bloom-staging-pipeline-credentials` — updated after the credential was actually
+  provisioned via the RunAI console, following the same `genericsecret-` prefix convention as
+  `WANDB_API_KEY`, with an explicit `-staging` suffix so a later production credential can't
+  collide with/overwrite this one); added `images-downloader` as the DAG root and `write-back` as
+  the final task; `predictor` depends on `images-downloader`; `write-back` depends on
+  `trait-extractor`.
 - [x] 3.2 In the same edit, changed `images-input-dir`'s `hostPath.type` from `Directory` to
   `DirectoryOrCreate`, and updated its comment: it no longer requires manual pre-staging —
   `images-downloader` now writes there automatically. `predictions-output-dir`/`traits-output-dir`
@@ -82,11 +86,13 @@ directly against the real RunAI cluster instead.
   actually exercise batch behavior, since that's the point of this change. `argo submit
   sleap-roots-pipeline.yaml --parameter scan-ids=<id1>,<id2> -n runai-talmo-lab`.
 - [ ] 5.3 Confirm the DAG structure resolves correctly at submit time (proves 3.4's cross-check was
-  right) and `images-downloader` schedules and starts. Its `bloomctl` auth is **expected to fail**
-  until the credential from sleap-roots-pipeline#17 lands (tracked separately, in progress) — a
-  clean `bloomctl` auth error here means the wiring is correct, not broken. If the credential
-  happens to be ready by test time, confirm a full successful run instead. Record which outcome
-  actually happened.
+  right) and `images-downloader` schedules and starts. The `genericsecret-
+  bloom-staging-pipeline-credentials` Secret now exists with real values (sleap-roots-pipeline#17
+  resolved for staging), so a **full successful run is the expected outcome** — confirm
+  `images-downloader` actually authenticates and stages real frames. If it instead fails at the
+  `bloomctl` auth step, that's a real bug to investigate (e.g. the RunAI console's multi-line value
+  got mangled, or the `secretName`/key don't actually match what the console produced), not an
+  expected gap. Record the actual result either way.
 - [ ] 5.4 Confirm `batch-download-for-predict --scan-ids ""` (the parameter's empty default)
   behavior matches what the source implies (`parse_scan_ids_flag("")` → `[]` → exit 0, "nothing to
   stage," not a CLI parse error) — submit once with no `scan-ids` override and record the actual

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -3,24 +3,28 @@
 ## Purpose
 
 `sleap-roots-pipeline` is the **orchestration layer** for the sleap-roots plant-root
-phenotyping pipeline. It declares how three containerized stages are wired together and
+phenotyping pipeline. It declares how four containerized stages are wired together and
 scheduled on a GPU cluster:
 
-1. **models-downloader** — prepares SLEAP model files for inference
-2. **predictor** — runs SLEAP predictions on input image sets (GPU)
+1. **images-downloader** — stages a batch of scans in from Bloom via `bloomctl` (batch-capable, A4)
+2. **predictor** — runs SLEAP predictions on the staged image sets (GPU)
 3. **trait-extractor** — extracts phenotypic traits from the predictions
+4. **write-back** — writes the resulting traits back into Bloom via `bloomctl` (batch-capable, A4)
 
 This repo holds **no application/library code of its own** — it is the declarative glue
 (Argo `Workflow` + `WorkflowTemplate` manifests and shell launchers) that runs images
-built and published by the sibling service repos (`models-downloader`,
-`sleap-roots-predict`, `sleap-roots` trait-extractor).
+built and published by the sibling service repos (`sleap-roots-predict`, `sleap-roots`
+trait-extractor, `salk-bloom`'s `bloomctl`).
 
-The roadmap target (see `docs/bloom-integration/roadmap.md`, tier **A4**) is to evolve
-this from a manually-launched batch pipeline into **event-driven, per-scan orchestration**:
-a scan ingested into Bloom triggers a per-scan Argo workflow (predict → traits →
-write-back with provenance) via Argo Events. That A4 design is **out of scope here** —
-this repo is currently at the **A0 tooling-baseline** stage (OpenSpec + canonical Claude
-commands).
+The roadmap target (see `docs/bloom-integration/roadmap.md`, tier **A4**) is
+**event-driven, per-batch orchestration**: a scan ingested into Bloom eventually triggers
+this per-batch Argo workflow (stage-in → predict → traits → write-back with provenance).
+**A4 is in progress, not out of scope** — the four-stage batch DAG above landed via
+`add-per-batch-argo-workflow` and was validated end-to-end on the real RunAI cluster
+(2026-07-30). Still open: the Bloom-side trigger route/dispatch worker (so a UI click
+submits this workflow instead of a manual `argo submit`), the Argo semaphore for
+concurrent-batch concurrency, and per-run path isolation — see the roadmap's A4
+change-breakdown table for the full remaining list.
 
 ## Tech Stack
 
@@ -61,11 +65,13 @@ are YAML manifests and shell scripts.
 
 ### Architecture Patterns
 
-- **Three-stage DAG**: models-downloader → predictor → trait-extractor, with
-  `dependencies:` enforcing order and `retryStrategy` handling preemption/transient
-  failures. Data passes between stages **via shared volume mounts, not Argo
-  parameters/artifacts** — one stage's output mount is the next stage's input mount, so
-  inter-stage coupling is mount-path agreement, not parameter wiring.
+- **Four-stage per-batch DAG**: images-downloader → predictor → trait-extractor →
+  write-back, with `dependencies:` enforcing order and `retryStrategy` handling
+  preemption/transient failures. Data passes between stages **via shared volume mounts,
+  not Argo parameters/artifacts** — one stage's output mount is the next stage's input
+  mount, so inter-stage coupling is mount-path agreement, not parameter wiring. (The one
+  exception is the `scan-ids` Workflow parameter, which `images-downloader` consumes to
+  know which batch to stage.)
 - **Templates are versioned, shared building blocks** (`argo template create …`), referenced
   by the workflow rather than inlined.
 - **Storage is mount-based**: model input, image input, and outputs are passed between
@@ -112,7 +118,9 @@ git/GitHub/OpenSpec/docs commands.
 - The broader program is tracked in `docs/bloom-integration/roadmap.md` (canonical for
   scope/sequencing) and Bloom EPIC #9 (canonical for Bloom-side implementation detail).
   This repo is the orchestration component slated to **deliver** roadmap tier **A4 —
-  event-driven orchestration**; it is currently at **A0** (this change) and A4 is not started.
+  event-driven orchestration**; A4 is **in progress** — the four-stage batch DAG is built
+  and cluster-validated, but the Bloom-side trigger route (so a UI click submits it,
+  rather than a manual `argo submit`) is not yet built.
 - **Vocabulary:** a *scan* is one imaging run of a plant; the pipeline runs per scan (A4),
   while experiment-level `analyze` is a separate, on-request path (not in this repo).
 

--- a/runai_run_pipeline.sh
+++ b/runai_run_pipeline.sh
@@ -34,8 +34,10 @@ echo "NOTE: Confirm that volume paths in your workflow YAML are cluster-accessib
 WORKFLOW_FILE="sleap-roots-pipeline.yaml"
 # A4: models-downloader dropped — the warm predictor loads models in-process.
 TEMPLATES=(
+  "sleap-roots-images-downloader-template.yaml"
   "sleap-roots-predictor-template.yaml"
   "sleap-roots-trait-extractor-template.yaml"
+  "sleap-roots-write-back-template.yaml"
 )
 
 # Log setup

--- a/runai_run_pipeline.sh
+++ b/runai_run_pipeline.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 # NOTE: this launcher targets the in-cluster Argo Server (gpu-master:8888) and requires ARGO_TOKEN
 # exported — it only works from a machine on the internal cluster LAN. The A4 PoC was NOT run this
-# way; it was submitted in Kubernetes mode (no Argo Server) with the argo-user kubeconfig:
+# way; it was submitted in Kubernetes mode (no Argo Server) with the argo-user kubeconfig, which is
+# also how the real four-stage end-to-end run (2026-07-30) was submitted:
 #   export KUBECONFIG=~/.kube/kubeconfig-runai-talmo-lab.yaml
-#   argo template update sleap-roots-predictor-template.yaml     -n runai-talmo-lab
-#   argo template update sleap-roots-trait-extractor-template.yaml -n runai-talmo-lab
-#   argo submit sleap-roots-pipeline.yaml -n runai-talmo-lab
+#   argo template update sleap-roots-images-downloader-template.yaml -n runai-talmo-lab
+#   argo template update sleap-roots-predictor-template.yaml         -n runai-talmo-lab
+#   argo template update sleap-roots-trait-extractor-template.yaml   -n runai-talmo-lab
+#   argo template update sleap-roots-write-back-template.yaml        -n runai-talmo-lab
+#   argo submit sleap-roots-pipeline.yaml --parameter scan-ids=<id1>,<id2> -n runai-talmo-lab
 # Use that path if gpu-master:8888 is unreachable from your box.
 
 # Color output

--- a/sleap-roots-images-downloader-template.yaml
+++ b/sleap-roots-images-downloader-template.yaml
@@ -1,7 +1,10 @@
 # https://argo-workflows.readthedocs.io/en/latest/fields/#workflowspec
 # A4: batch stage-in via bloomctl (bloom #532). Image is a commit-sha tag auto-built on bloomcli's
 # push to `staging` — no versioned bloomcli release exists yet, so this is the only correct
-# reference for now; expect to bump it once a real version tag exists.
+# reference for now; expect to bump it once a real version tag exists. Tighten to `@sha256:<digest>`
+# once bloomcli publishes one (a `sha-<gitsha>` tag is immutable in *name* only — a re-run of the
+# build workflow against the same commit would silently overwrite it in GHCR unless immutable tags
+# are enabled on that package; unverified from this repo).
 # Bumped 2026-07-30: sha-61959bd (#532) -> sha-c21d11b (bloom #556, fixes #555 — build_sidecar()
 # now writes image_ids as str via sleap_roots_contracts.InputRef; scan_is_already_staged() now
 # rejects pre-fix int-typed sidecars so already-staged scans re-stage cleanly).
@@ -17,7 +20,12 @@ spec:
       # CPU-only, I/O-bound (HTTPS calls) — trait-extractor's retry pattern, not predictor's GPU one.
       priorityClassName: interactive-preemptible
       retryStrategy:
+        # retryPolicy Always (not just the default OnFailure) matters here: this shares
+        # trait-extractor's preemptible priority class, and RunAI eviction under CPU-pool
+        # over-quota contention typically surfaces as an Error-phase node, which OnFailure does
+        # not retry.
         limit: 2
+        retryPolicy: Always
       container:
         image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-c21d11b
         imagePullPolicy: Always
@@ -37,10 +45,9 @@ spec:
         volumeMounts:
           - name: images-input-dir
             mountPath: /workspace/images_input
-          # Placeholder reference — the Secret itself is provisioned by a separate, in-progress
-          # workstream (sleap-roots-pipeline#17). Until it exists with real values, this task fails
-          # at volume-mount (Secret absent) or at bloomctl auth (Secret exists but incomplete) —
-          # both expected, not a sign of broken wiring.
+          # Provisioned (2026-07-29) via the RunAI console as a Generic secret — resolves
+          # sleap-roots-pipeline#17 for staging. Confirmed working end-to-end on the real cluster
+          # (real auth, real staging) — see the OpenSpec change's design.md/tasks.md.
           - name: bloom-credentials
             mountPath: /home/bloom/.bloom/credentials.txt
             subPath: credentials.txt

--- a/sleap-roots-images-downloader-template.yaml
+++ b/sleap-roots-images-downloader-template.yaml
@@ -1,0 +1,53 @@
+# https://argo-workflows.readthedocs.io/en/latest/fields/#workflowspec
+# A4: batch stage-in via bloomctl (bloom #532). Image is a commit-sha tag auto-built on bloomcli's
+# push to `staging` — no versioned bloomcli release exists yet, so this is the only correct
+# reference for now; expect to bump it once a real version tag exists.
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: sleap-roots-images-downloader-template
+  labels:
+    project: talmo-lab
+spec:
+  templates:
+    - name: images-downloader
+      # CPU-only, I/O-bound (HTTPS calls) — trait-extractor's retry pattern, not predictor's GPU one.
+      priorityClassName: interactive-preemptible
+      retryStrategy:
+        limit: 2
+      container:
+        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+        imagePullPolicy: Always
+        args:
+          - "cyl"
+          - "batch-download-for-predict"
+          - "/workspace/images_input"
+          - "--scan-ids"
+          - "{{workflow.parameters.scan-ids}}"
+        env:
+          # bloomcli's Dockerfile creates its runtime user via `adduser --system` with no explicit
+          # home directory, so Python's Path.home() (which bloomctl's credential lookup uses) is
+          # ambiguous without this. Setting HOME here makes ~/.bloom/credentials.txt resolve
+          # deterministically to the path the bloom-credentials volume below is mounted at.
+          - name: HOME
+            value: /home/bloom
+        volumeMounts:
+          - name: images-input-dir
+            mountPath: /workspace/images_input
+          # Placeholder reference — the Secret itself is provisioned by a separate, in-progress
+          # workstream (sleap-roots-pipeline#17). Until it exists with real values, this task fails
+          # at volume-mount (Secret absent) or at bloomctl auth (Secret exists but incomplete) —
+          # both expected, not a sign of broken wiring.
+          - name: bloom-credentials
+            mountPath: /home/bloom/.bloom/credentials.txt
+            subPath: credentials.txt
+            readOnly: true
+        # No privileged/runAsUser:0 — unlike predictor/trait-extractor, this genuinely doesn't need
+        # it (non-root image, no GPU, no device access).
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi

--- a/sleap-roots-images-downloader-template.yaml
+++ b/sleap-roots-images-downloader-template.yaml
@@ -2,6 +2,9 @@
 # A4: batch stage-in via bloomctl (bloom #532). Image is a commit-sha tag auto-built on bloomcli's
 # push to `staging` — no versioned bloomcli release exists yet, so this is the only correct
 # reference for now; expect to bump it once a real version tag exists.
+# Bumped 2026-07-30: sha-61959bd (#532) -> sha-c21d11b (bloom #556, fixes #555 — build_sidecar()
+# now writes image_ids as str via sleap_roots_contracts.InputRef; scan_is_already_staged() now
+# rejects pre-fix int-typed sidecars so already-staged scans re-stage cleanly).
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -16,7 +19,7 @@ spec:
       retryStrategy:
         limit: 2
       container:
-        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-c21d11b
         imagePullPolicy: Always
         args:
           - "cyl"

--- a/sleap-roots-pipeline.yaml
+++ b/sleap-roots-pipeline.yaml
@@ -13,17 +13,25 @@ metadata:
 spec:
   entrypoint: pipeline
 
+  arguments:
+    parameters:
+      # Comma-separated scan_ids, passed straight through to images-downloader's --scan-ids.
+      # Submit with e.g. `argo submit sleap-roots-pipeline.yaml --parameter scan-ids=1,2,3`.
+      - name: scan-ids
+        value: ""
+
   volumes:
     # A4: models-downloader dropped — the warm predictor loads models in-process from the
     # wandb registry, so no models-input/models-output volumes.
     # NOTE: hostPath onto the /hpi/hpi_dev NFS — cross-node reschedule/resume only works because
-    # that mount exists at the SAME path on every GPU node. Input is type:Directory (the staged
-    # scan MUST pre-exist); outputs are DirectoryOrCreate so a fresh run/node doesn't FailedMount.
+    # that mount exists at the SAME path on every GPU node. images-input-dir is now staged
+    # automatically by images-downloader (DirectoryOrCreate — no human needs to have pre-staged a
+    # scan here first); the other two are DirectoryOrCreate so a fresh run/node doesn't FailedMount.
     # These a4_poc paths are the PoC reference scan — a real per-scan trigger parameterizes them (#10).
     - name: images-input-dir
       hostPath:
         path: /hpi/hpi_dev/users/eberrigan/pipeline_orchestration_tests/a4_poc/input
-        type: Directory
+        type: DirectoryOrCreate
     - name: predictions-output-dir
       hostPath:
         path: /hpi/hpi_dev/users/eberrigan/pipeline_orchestration_tests/a4_poc/predictions
@@ -32,17 +40,35 @@ spec:
       hostPath:
         path: /hpi/hpi_dev/users/eberrigan/pipeline_orchestration_tests/a4_poc/traits
         type: DirectoryOrCreate
+    - name: bloom-credentials
+      # Provisioned by a separate, in-progress workstream (sleap-roots-pipeline#17). Until it
+      # exists with real values, images-downloader/write-back fail at volume-mount (Secret absent)
+      # or bloomctl auth (Secret exists but incomplete) — both expected, not broken wiring.
+      secret:
+        secretName: bloom-pipeline-credentials
   templates:
     - name: pipeline
       dag:
         tasks:
+          - name: images-downloader
+            templateRef:
+              name: sleap-roots-images-downloader-template
+              template: images-downloader
           - name: predictor
             templateRef:
               name: sleap-roots-predictor-template
               template: predictor
+            dependencies:
+              - images-downloader
           - name: trait-extractor
             templateRef:
               name: sleap-roots-trait-extractor-template
               template: trait-extractor
             dependencies:
               - predictor
+          - name: write-back
+            templateRef:
+              name: sleap-roots-write-back-template
+              template: write-back
+            dependencies:
+              - trait-extractor

--- a/sleap-roots-pipeline.yaml
+++ b/sleap-roots-pipeline.yaml
@@ -27,6 +27,11 @@ spec:
     # that mount exists at the SAME path on every GPU node. images-input-dir is now staged
     # automatically by images-downloader (DirectoryOrCreate — no human needs to have pre-staged a
     # scan here first); the other two are DirectoryOrCreate so a fresh run/node doesn't FailedMount.
+    # ⚠️ Unverified on a truly cold path: kubelet creates a DirectoryOrCreate hostPath as root with a
+    # restrictive mode, and images-downloader's container deliberately runs non-root (see its
+    # template) — a fresh node/path with no prior ownership could hit a permission-denied write
+    # rather than a clean stage-in. The real cluster run that validated this reused an
+    # already-existing, already-writable path, so this specific edge case wasn't exercised.
     # These a4_poc paths are the PoC reference scan — a real per-scan trigger parameterizes them (#10).
     - name: images-input-dir
       hostPath:

--- a/sleap-roots-pipeline.yaml
+++ b/sleap-roots-pipeline.yaml
@@ -41,11 +41,13 @@ spec:
         path: /hpi/hpi_dev/users/eberrigan/pipeline_orchestration_tests/a4_poc/traits
         type: DirectoryOrCreate
     - name: bloom-credentials
-      # Provisioned by a separate, in-progress workstream (sleap-roots-pipeline#17). Until it
-      # exists with real values, images-downloader/write-back fail at volume-mount (Secret absent)
-      # or bloomctl auth (Secret exists but incomplete) — both expected, not broken wiring.
+      # Provisioned via the RunAI console (Credentials → Generic secret, Project scope
+      # talmo-lab), same as WANDB_API_KEY — RunAI prefixes the asset name with `genericsecret-`
+      # in the resulting k8s Secret. Named with an explicit -staging suffix (not just
+      # bloom-pipeline-credentials) so a later production credential gets its own distinct name
+      # instead of colliding with/overwriting this one in the same namespace.
       secret:
-        secretName: bloom-pipeline-credentials
+        secretName: genericsecret-bloom-staging-pipeline-credentials
   templates:
     - name: pipeline
       dag:

--- a/sleap-roots-write-back-template.yaml
+++ b/sleap-roots-write-back-template.yaml
@@ -1,6 +1,8 @@
 # https://argo-workflows.readthedocs.io/en/latest/fields/#workflowspec
 # A4: batch write-back via bloomctl (bloom #532). Same image-pin rationale as
 # sleap-roots-images-downloader-template.yaml.
+# Bumped 2026-07-30: sha-61959bd (#532) -> sha-c21d11b (bloom #556, fixes #555 — see
+# sleap-roots-images-downloader-template.yaml for details).
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -15,7 +17,7 @@ spec:
       retryStrategy:
         limit: 2
       container:
-        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-c21d11b
         imagePullPolicy: Always
         args:
           - "cyl"

--- a/sleap-roots-write-back-template.yaml
+++ b/sleap-roots-write-back-template.yaml
@@ -1,6 +1,6 @@
 # https://argo-workflows.readthedocs.io/en/latest/fields/#workflowspec
-# A4: batch write-back via bloomctl (bloom #532). Same image-pin rationale as
-# sleap-roots-images-downloader-template.yaml.
+# A4: batch write-back via bloomctl (bloom #532). Same image-pin rationale (including the
+# tag-mutability caveat) as sleap-roots-images-downloader-template.yaml.
 # Bumped 2026-07-30: sha-61959bd (#532) -> sha-c21d11b (bloom #556, fixes #555 — see
 # sleap-roots-images-downloader-template.yaml for details).
 apiVersion: argoproj.io/v1alpha1
@@ -15,7 +15,9 @@ spec:
       # CPU-only, I/O-bound (HTTPS calls) — trait-extractor's retry pattern, not predictor's GPU one.
       priorityClassName: interactive-preemptible
       retryStrategy:
+        # See sleap-roots-images-downloader-template.yaml for why retryPolicy is explicit here.
         limit: 2
+        retryPolicy: Always
       container:
         image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-c21d11b
         imagePullPolicy: Always
@@ -34,8 +36,8 @@ spec:
             mountPath: /workspace/input
           - name: predictions-output-dir
             mountPath: /workspace/predictions
-          # Placeholder reference — see sleap-roots-images-downloader-template.yaml; provisioned by
-          # sleap-roots-pipeline#17, in progress.
+          # Provisioned — see sleap-roots-images-downloader-template.yaml (sleap-roots-pipeline#17,
+          # resolved for staging, confirmed working end-to-end on the real cluster).
           - name: bloom-credentials
             mountPath: /home/bloom/.bloom/credentials.txt
             subPath: credentials.txt

--- a/sleap-roots-write-back-template.yaml
+++ b/sleap-roots-write-back-template.yaml
@@ -1,0 +1,48 @@
+# https://argo-workflows.readthedocs.io/en/latest/fields/#workflowspec
+# A4: batch write-back via bloomctl (bloom #532). Same image-pin rationale as
+# sleap-roots-images-downloader-template.yaml.
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: sleap-roots-write-back-template
+  labels:
+    project: talmo-lab
+spec:
+  templates:
+    - name: write-back
+      # CPU-only, I/O-bound (HTTPS calls) — trait-extractor's retry pattern, not predictor's GPU one.
+      priorityClassName: interactive-preemptible
+      retryStrategy:
+        limit: 2
+      container:
+        image: ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-61959bd
+        imagePullPolicy: Always
+        args:
+          - "cyl"
+          - "batch-ingest-result"
+          - "/workspace/input"
+          - "--predictions-dir"
+          - "/workspace/predictions"
+        env:
+          # See sleap-roots-images-downloader-template.yaml for why HOME is set explicitly.
+          - name: HOME
+            value: /home/bloom
+        volumeMounts:
+          - name: traits-output-dir
+            mountPath: /workspace/input
+          - name: predictions-output-dir
+            mountPath: /workspace/predictions
+          # Placeholder reference — see sleap-roots-images-downloader-template.yaml; provisioned by
+          # sleap-roots-pipeline#17, in progress.
+          - name: bloom-credentials
+            mountPath: /home/bloom/.bloom/credentials.txt
+            subPath: credentials.txt
+            readOnly: true
+        # No privileged/runAsUser:0 — see sleap-roots-images-downloader-template.yaml.
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi


### PR DESCRIPTION
## Summary

Replaces the A4 PoC's hardcoded two-task DAG (`predictor → trait-extractor` against one fixed, manually pre-staged scan) with a real four-task per-batch pipeline: `images-downloader → predictor → trait-extractor → write-back`, wiring in bloomctl's new batch commands ([bloom #532](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/532)).

## Changes

- Add `sleap-roots-images-downloader-template.yaml`: runs `bloomctl cyl batch-download-for-predict` against a caller-supplied `scan-ids` Workflow parameter.
- Add `sleap-roots-write-back-template.yaml`: runs `bloomctl cyl batch-ingest-result --predictions-dir`.
- Both pin `ghcr.io/salk-harnessing-plants-initiative/bloomctl:sha-c21d11b` (bumped from `sha-61959bd` after [bloom #556](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/556) fixed [#555](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/555), see Verification — no versioned `bloomcli` release exists yet, so this is still the only correct reference), set `HOME=/home/bloom` explicitly (the image's runtime user has no deterministic home dir otherwise), and mount a `bloom-credentials` Secret at `$HOME/.bloom/credentials.txt` — wired to the real `genericsecret-bloom-staging-pipeline-credentials` Secret, created via the RunAI console (Credentials → Generic secret), resolving sleap-roots-pipeline#17 for staging. The `genericsecret-` prefix matches the existing `WANDB_API_KEY` precedent; the `-staging` suffix is deliberate, so a later production credential gets its own name instead of colliding with this one.
- Rewrite `sleap-roots-pipeline.yaml`'s DAG to the four-stage chain; add the `scan-ids` parameter and `bloom-credentials` volume; fix `images-input-dir`'s `hostPath.type` from `Directory` to `DirectoryOrCreate` (it's now auto-populated by `images-downloader` instead of requiring manual pre-staging — the old type would `FailedMount` on a never-before-staged path).
- Register both new templates in `runai_run_pipeline.sh`.
- `predictor`/`trait-extractor` templates and all `local-WSL2-*` files are untouched — local dev testing for this DAG shape is out of scope here (Docker Desktop Kubernetes has no GPU resource on this machine, verified live; tracked in updated issue #21).

## OpenSpec Change

- Change ID: `add-per-batch-argo-workflow`
- Affected capabilities: ADD `per-batch-pipeline`, REMOVE `per-scan-pipeline` (superseded — single-scan support isn't lost, it's a batch of size 1; each removed requirement's migration note points at its replacement)
- All `tasks.md` items complete: essentially yes — the only thing not separately re-confirmed is `--scan-ids ""` empty-input behavior (low priority now that the real batch path is proven end-to-end); see Verification below.

## Verification

- [x] `argo lint` (v3.6.5, via WSL — not on Windows PATH, see the `runai` skill) passes on both new templates
- [!] `argo lint sleap-roots-pipeline.yaml` reports one error: `templates.pipeline.tasks.images-downloader couldn't find workflow template "sleap-roots-images-downloader-template" in namespace "runai-talmo-lab"` — this is the same known limitation the archived `add-per-scan-argo-workflow` change documented (offline lint can't cross-resolve `templateRef`s against an unregistered namespace); manually cross-checked the `templateRef.name`/`template` values against the new files' `metadata.name`/`templates[].name` and confirmed exact matches. Full cross-resolution happens after `argo template create`, in the still-pending cluster submit.
- [x] `openspec validate add-per-batch-argo-workflow --strict` passes
- [x] Cluster/local variants: local-WSL2 files intentionally untouched (see Changes above), tracked in #21 — N/A for this PR
- [x] **Real cluster submit — full success.** `sleap-roots-pipeline-v4lg7`: `Status: Succeeded`, `Progress: 4/4`, all four stages green (`images-downloader` 6s → `predictor` 2m → `trait-extractor` 12s → `write-back` 8s) against 3 real staged scans (`--parameter scan-ids=289,577,1009`). Confirmed `write-back` was real, not just `exit 0`: manually re-`ingest-result`-ed all 3 result envelopes via `bloomctl` afterward — each returned `"was_noop": true` with real `source_id`s (6, 7, 8), Bloom's actual idempotent first-writer-wins response, proving the original write-back created real `cyl_trait_sources` rows in the staging database. **This is the first fully-real end-to-end A4 run.**
  - Getting here surfaced two real, external findings along the way: (1) a confirmed, pre-existing `bloomctl` bug (`image_ids` written as int, `ScanMetadata` requires str, present since bloom #458) blocked the first attempt — filed as [bloom #555](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/555), fixed in [bloom #556](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/556) (merged to staging, `c21d11b`), which this PR's image pin was then bumped to. (2) After that fix, `predictor` skipped re-running (valid predictions already existed) and so never re-copied the corrected sidecar forward into its own output directory — `trait-extractor` briefly failed identically again until the 3 scans' prediction outputs were manually cleared to force a real re-run. Documented as a new risk in `design.md` (skip-if-done can serve stale copied-through data after an upstream *data* fix, not just a code fix).
  - Also surfaced for real (not just theoretical, on an earlier attempt): the already-documented shared-path/no-per-run-isolation limitation — a leftover scan from an earlier submit got reprocessed by `predictor`'s directory-wide scan, requiring a manual cleanup before a clean run. Issue #21 updated with this confirmation.
- [x] No `ARGO_TOKEN`/secrets committed or echoed

## Breaking Changes

- [x] Breaking changes documented below with migration path

Once merged and redeployed, the currently-working manual `argo submit` flow's DAG shape changes — a full run now depends on `images-downloader` succeeding first. **Confirmed working for real, end-to-end, on staging** (see Verification) — not just expected to work.

## Related Issues

Related to talmolab/sleap-roots-pipeline#10 (A4 EPIC), talmolab/sleap-roots-pipeline#17 (credential — resolved for staging via the RunAI console), talmolab/sleap-roots-pipeline#21 (local dev testing — confirmed for real that the leftover-scan/shared-path limitation this issue tracks is a real gap, not just theoretical), [bloom #555](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/issues/555)/[#556](https://github.com/Salk-Harnessing-Plants-Initiative/bloom/pull/556) (external `bloomctl` bug found via this PR's real cluster test, fixed upstream)

## Reviewer Notes

- This PR was reviewed via `/review-openspec` (5-subagent adversarial review) before implementation — findings incorporated: the `DirectoryOrCreate` fix, the multi-scan-id batch test requirement, the `templateRef` name cross-check, the `project: talmo-lab` label, the BREAKING flag, and the corrected credential-failure-mode framing.
- **Real cluster submit completed with full success** (task 5) — all four stages, real data, real credential, real write-back into Bloom staging. See Verification for the two external findings (bloom #555/#556, and a skip-if-done/stale-copy-through interaction) surfaced along the way.
- `write-back` shares `trait-extractor`'s known "empty input → exit 0" gap (sleap-roots#259) — an empty batch could make all four DAG nodes go green with zero real work. Not addressed here; tracked as part of the already-deferred producer Argo-readiness reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


